### PR TITLE
marshaler float from int64, float64, timestamp from string support

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -937,6 +937,12 @@ func marshalFloat(info TypeInfo, value interface{}) ([]byte, error) {
 		return nil, nil
 	case float32:
 		return encInt(int32(math.Float32bits(v))), nil
+	case int64:
+		return encInt(int32(math.Float32bits(float32(v)))), nil
+	case float64:
+		f := float32(v)
+		return encInt(int32(math.Float32bits(f))), nil
+
 	}
 
 	if value == nil {
@@ -955,6 +961,7 @@ func unmarshalFloat(info TypeInfo, data []byte, value interface{}) error {
 	switch v := value.(type) {
 	case Unmarshaler:
 		return v.UnmarshalCQL(info, data)
+
 	case *float32:
 		*v = math.Float32frombits(uint32(decInt(data)))
 		return nil
@@ -1098,6 +1105,18 @@ func marshalTimestamp(info TypeInfo, value interface{}) ([]byte, error) {
 		return nil, nil
 	case int64:
 		return encBigInt(v), nil
+	case string:
+		defaultLayout := time.RFC3339
+		if len(v) < len(defaultLayout) {
+			defaultLayout = string(defaultLayout[:len(v)])
+		}
+		t, err := time.Parse(defaultLayout, v)
+		if err != nil {
+			return nil, err
+		}
+		x := int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
+		return encBigInt(x), nil
+
 	case time.Time:
 		if v.IsZero() {
 			return []byte{}, nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -654,6 +654,7 @@ var marshalTests = []struct {
 		nil,
 		nil,
 	},
+
 	{
 		NativeType{proto: 2, typ: TypeFloat},
 		[]byte(nil),
@@ -1253,6 +1254,21 @@ func TestMarshalTimestamp(t *testing.T) {
 			NativeType{proto: 2, typ: TypeTimestamp},
 			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa5\x09"),
 			time.Date(1677, time.September, 21, 00, 12, 43, 145224192, time.UTC),
+		},
+
+		{
+			// -9223372036855 is the minimum time representable in ms since the epoch
+			// with int64 if using UnixNano to convert
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa4\x78"),
+			"1677-09-21T00:12:43Z",
+		},
+		{
+			// -9223372036855 is the minimum time representable in ms since the epoch
+			// with int64 if using UnixNano to convert
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa4\x78"),
+			"1677-09-21T00:12:43",
 		},
 		{
 			// One nanosecond earlier causes overflow when using UnixNano


### PR DESCRIPTION
marshaler float from int64, float64, timestamp from string support to integrate with e2e testing framework (viant/endly) via dependencies https://github.com/viant/dsunit/tree/casandra and https://github.com/viant/dsc/tree/casandra