### PR TITLE
partition prepared statementcache by host

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1327,8 +1327,9 @@ func injectInvalidPreparedStatement(t *testing.T, session *Session, table string
 	conn := getRandomConn(t, session)
 
 	flight := new(inflightPrepare)
-	key := session.stmtsLRU.keyFor(conn.addr, "", stmt)
-	session.stmtsLRU.add(key, flight)
+	stmtLRU := session.stmtsLRU.forHost(conn.addr)
+	key := stmtLRU.keyFor("", stmt)
+	stmtLRU.add(key, flight)
 
 	flight.preparedStatment = &preparedStatment{
 		id: []byte{'f', 'o', 'o', 'b', 'a', 'r'},
@@ -1484,40 +1485,35 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 		t.Fatalf("insert into prepcachetest failed, error '%v'", err)
 	}
 
-	session.stmtsLRU.mu.Lock()
-	defer session.stmtsLRU.mu.Unlock()
-
-	//Make sure the cache size is maintained
-	if session.stmtsLRU.lru.Len() != session.stmtsLRU.lru.MaxEntries {
-		t.Fatalf("expected cache size of %v, got %v", session.stmtsLRU.lru.MaxEntries, session.stmtsLRU.lru.Len())
-	}
-
 	// Walk through all the configured hosts and test cache retention and eviction
 	for _, host := range session.cfg.Hosts {
-		_, ok := session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 0"))
+		stmtLRU := session.stmtsLRU.forHost(host + ":9042")
+		stmtLRU.mu.Lock()
+		_, ok := stmtLRU.lru.Get(stmtLRU.keyFor(session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 0"))
 		if ok {
 			t.Errorf("expected first select to be purged but was in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 1"))
+		_, ok = stmtLRU.lru.Get(stmtLRU.keyFor(session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 1"))
 		if !ok {
 			t.Errorf("exepected second select to be in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "INSERT INTO prepcachetest (id,mod) VALUES (?, ?)"))
+		_, ok = stmtLRU.lru.Get(stmtLRU.keyFor(session.cfg.Keyspace, "INSERT INTO prepcachetest (id,mod) VALUES (?, ?)"))
 		if !ok {
 			t.Errorf("expected insert to be in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "UPDATE prepcachetest SET mod = ? WHERE id = ?"))
+		_, ok = stmtLRU.lru.Get(stmtLRU.keyFor(session.cfg.Keyspace, "UPDATE prepcachetest SET mod = ? WHERE id = ?"))
 		if !ok {
 			t.Errorf("expected update to be in cached for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "DELETE FROM prepcachetest WHERE id = ?"))
+		_, ok = stmtLRU.lru.Get(stmtLRU.keyFor(session.cfg.Keyspace, "DELETE FROM prepcachetest WHERE id = ?"))
 		if !ok {
 			t.Errorf("expected delete to be cached for host=%q", host)
 		}
+		stmtLRU.mu.Unlock()
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -227,7 +227,7 @@ func (s *Session) dialWithoutObserver(host *HostInfo, cfg *ConnConfig, errorHand
 		cfg:           cfg,
 		calls:         make(map[int]*callReq),
 		version:       uint8(cfg.ProtoVersion),
-		addr:          conn.RemoteAddr().String(),
+		addr:          addr,
 		errorHandler:  errorHandler,
 		compressor:    cfg.Compressor,
 		quit:          make(chan struct{}),
@@ -951,8 +951,9 @@ type inflightPrepare struct {
 }
 
 func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer) (*preparedStatment, error) {
-	stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
-	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func(lru *lru.Cache) *inflightPrepare {
+	stmtsLRU := c.session.stmtsLRU.forHost(c.addr)
+	stmtCacheKey := stmtsLRU.keyFor(c.currentKeyspace, stmt)
+	flight, ok := stmtsLRU.execIfMissing(stmtCacheKey, func(lru *lru.Cache) *inflightPrepare {
 		flight := new(inflightPrepare)
 		flight.wg.Add(1)
 		lru.Add(stmtCacheKey, flight)
@@ -975,7 +976,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 	if err != nil {
 		flight.err = err
 		flight.wg.Done()
-		c.session.stmtsLRU.remove(stmtCacheKey)
+		stmtsLRU.remove(stmtCacheKey)
 		return nil, err
 	}
 
@@ -983,7 +984,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 	if err != nil {
 		flight.err = err
 		flight.wg.Done()
-		c.session.stmtsLRU.remove(stmtCacheKey)
+		stmtsLRU.remove(stmtCacheKey)
 		return nil, err
 	}
 
@@ -1012,7 +1013,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 	flight.wg.Done()
 
 	if flight.err != nil {
-		c.session.stmtsLRU.remove(stmtCacheKey)
+		stmtsLRU.remove(stmtCacheKey)
 	}
 
 	return flight.preparedStatment, flight.err
@@ -1178,8 +1179,9 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		// is not consistent with regards to its schema.
 		return iter
 	case *RequestErrUnprepared:
-		stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, qry.stmt)
-		if c.session.stmtsLRU.remove(stmtCacheKey) {
+		stmtsLRU := c.session.stmtsLRU.forHost(c.addr)
+		stmtCacheKey := stmtsLRU.keyFor(c.currentKeyspace, qry.stmt)
+		if stmtsLRU.remove(stmtCacheKey) {
 			return c.executeQuery(ctx, qry)
 		}
 
@@ -1320,17 +1322,15 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) *Iter {
 	case *resultVoidFrame:
 		return &Iter{}
 	case *RequestErrUnprepared:
-		stmt, found := stmts[string(x.StatementId)]
-		if found {
-			key := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
-			c.session.stmtsLRU.remove(key)
+		stmt, ok := stmts[string(x.StatementId)]
+		if ok {
+			stmtsLRU := c.session.stmtsLRU.forHost(c.addr)
+			stmtCacheKey := stmtsLRU.keyFor(c.currentKeyspace, stmt)
+			stmtsLRU.remove(stmtCacheKey)
+			return c.executeBatch(ctx, batch)
 		}
 
-		if found {
-			return c.executeBatch(ctx, batch)
-		} else {
-			return &Iter{err: x, framer: framer}
-		}
+		return &Iter{err: x, framer: framer}
 	case *resultRowsFrame:
 		iter := &Iter{
 			meta:    x.meta,

--- a/events.go
+++ b/events.go
@@ -183,6 +183,7 @@ func (s *Session) addNewNode(host *HostInfo) {
 		return
 	}
 
+	s.stmtsLRU.HostUp(host)
 	host.setState(NodeUp)
 	s.pool.addHost(host)
 	s.policy.AddHost(host)
@@ -241,6 +242,7 @@ func (s *Session) handleRemovedNode(ip net.IP, port int) {
 	s.policy.RemoveHost(host)
 	s.pool.removeHost(ip)
 	s.ring.removeHost(ip)
+	s.stmtsLRU.HostDown(host)
 
 	if !s.cfg.IgnorePeerAddr {
 		s.hostSource.refreshRing()

--- a/session.go
+++ b/session.go
@@ -42,7 +42,7 @@ type Session struct {
 	connectObserver     ConnectObserver
 	frameObserver       FrameHeaderObserver
 	hostSource          *ringDescriber
-	stmtsLRU            *preparedLRU
+	stmtsLRU            *preparedCache
 
 	connCfg *ConnConfig
 
@@ -118,7 +118,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		prefetch:        0.25,
 		cfg:             cfg,
 		pageSize:        cfg.PageSize,
-		stmtsLRU:        &preparedLRU{lru: lru.New(cfg.MaxPreparedStmts)},
+		stmtsLRU:        &preparedCache{maxStmnts: cfg.MaxPreparedStmts},
 		quit:            make(chan struct{}),
 		connectObserver: cfg.ConnectObserver,
 	}


### PR DESCRIPTION
Prepared statements are only valid for the host they are prepared on so
we can avoid contending when concurrently querying multiple hosts.

Store the map of hosts->LRU in a copy-on-write map.

updates #1291 