### PR TITLE
Read consistency setting with a lock to avoid a data race.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1232,7 +1232,7 @@ func (c *Conn) AvailableStreams() int {
 
 func (c *Conn) UseKeyspace(keyspace string) error {
 	q := &writeQueryFrame{statement: `USE "` + keyspace + `"`}
-	q.params.consistency = c.session.cons
+	q.params.consistency = c.session.GetConsistency()
 
 	framer, err := c.exec(c.ctx, q, nil)
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -1232,7 +1232,7 @@ func (c *Conn) AvailableStreams() int {
 
 func (c *Conn) UseKeyspace(keyspace string) error {
 	q := &writeQueryFrame{statement: `USE "` + keyspace + `"`}
-	q.params.consistency = c.session.GetConsistency()
+	q.params.consistency = c.session.getConsistency()
 
 	framer, err := c.exec(c.ctx, q, nil)
 	if err != nil {

--- a/session.go
+++ b/session.go
@@ -337,6 +337,14 @@ func (s *Session) SetConsistency(cons Consistency) {
 	s.mu.Unlock()
 }
 
+// GetConsistency gets the default consistency level for this session.
+func (s *Session) GetConsistency() Consistency {
+	s.mu.RLock()
+	cons := s.cons
+	s.mu.RUnlock()
+	return cons
+}
+
 // SetPageSize sets the default page size for this session. A value <= 0 will
 // disable paging. This setting can also be changed on a per-query basis.
 func (s *Session) SetPageSize(n int) {

--- a/session.go
+++ b/session.go
@@ -337,8 +337,8 @@ func (s *Session) SetConsistency(cons Consistency) {
 	s.mu.Unlock()
 }
 
-// GetConsistency gets the default consistency level for this session.
-func (s *Session) GetConsistency() Consistency {
+// getConsistency gets the default consistency level for this session.
+func (s *Session) getConsistency() Consistency {
 	s.mu.RLock()
 	cons := s.cons
 	s.mu.RUnlock()


### PR DESCRIPTION
Fixes #1473.