### PR TITLE
Set the right value in custom property of Custom type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,3 +141,4 @@ Dmitry Kropachev <dmitry.kropachev@gmail.com>
 Oliver Boyle <pleasedontspamme4321+gocql@gmail.com>
 Jackson Fleming <jackson.fleming@instaclustr.com>
 Sylwia Szunejko <sylwia.szunejko@scylladb.com>
+Mathieu Morlon <glutamatt@live.fr>

--- a/helpers.go
+++ b/helpers.go
@@ -181,9 +181,14 @@ func getCassandraType(name string, logger StdLogger) TypeInfo {
 			Elems:      types,
 		}
 	} else {
+		bType := getCassandraBaseType(name)
+		custom := ""
+		if bType == TypeCustom {
+			custom = name
+		}
 		return NativeType{
-			typ:    getCassandraBaseType(name),
-			custom: name,
+			typ:    bType,
+			custom: custom,
 		}
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -182,7 +182,8 @@ func getCassandraType(name string, logger StdLogger) TypeInfo {
 		}
 	} else {
 		return NativeType{
-			typ: getCassandraBaseType(name),
+			typ:    getCassandraBaseType(name),
+			custom: name,
 		}
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -181,14 +181,10 @@ func getCassandraType(name string, logger StdLogger) TypeInfo {
 			Elems:      types,
 		}
 	} else {
-		bType := getCassandraBaseType(name)
-		custom := ""
-		if bType == TypeCustom {
-			custom = name
-		}
-		return NativeType{
-			typ:    bType,
-			custom: custom,
+		if bType := getCassandraBaseType(name); bType == TypeCustom {
+			return NativeType{typ: bType, custom: name}
+		} else {
+			return NativeType{typ: bType}
 		}
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -199,6 +199,12 @@ func TestGetCassandraType(t *testing.T) {
 				Elem:       NativeType{typ: TypeDuration},
 			},
 		},
+		{
+			"frozen<list<frozen<my_udt_custom>>>", CollectionType{
+				NativeType: NativeType{typ: TypeList},
+				Elem:       NativeType{typ: TypeCustom, custom: "my_udt_custom"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
i found https://github.com/gocql/gocql/issues/1053 

Custom type without any clue make the metadata unusable when dealing with udts

i get the complexity of udt types but at least, custom value for custom types could be set when custom is used as fallback for even for udts

after this patch , one can have information about the underlying custom type ( and build feature based on metadata )
