### PR TITLE
Add rows writers

### DIFF
--- a/bench_writers_test.go
+++ b/bench_writers_test.go
@@ -1,0 +1,123 @@
+package gocql
+
+import (
+	"fmt"
+	"github.com/gocql/gocql/pkg/writers/row"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func BenchmarkWriters_test(b *testing.B) {
+	b.ReportAllocs()
+	runWritersSet(10000, b)
+	runWritersSet(100, b)
+	runWritersSet(2, b)
+}
+
+func runWritersSet(rows int, b *testing.B) {
+	setName := fmt.Sprintf("rows count %d", rows)
+	data := randInts(rows, 3)
+	b.Run(setName, func(b *testing.B) {
+		fmt.Println("--------------------------------------", setName, "---------------------------------------")
+		b.Run(setName+"oldUnmarshal", func(b *testing.B) {
+			var out []row.ExampleStruct
+			for i := 0; i < b.N; i++ {
+				out = oldUnmarshal(data, rows)
+			}
+			if len(out) == 0 {
+				b.Fatal("oldUnmarshal fail")
+			}
+		})
+		b.Run(setName+"newUnmarshal", func(b *testing.B) {
+			var out []row.ExampleStruct
+			for i := 0; i < b.N; i++ {
+				out = newUnmarshal(data, rows)
+			}
+			if len(out) == 0 {
+				b.Fatal("newUnmarshal fail")
+			}
+		})
+	})
+}
+
+func oldUnmarshal(data []byte, rows int) []row.ExampleStruct {
+	var err error
+	var valLen int32
+	out := make([]row.ExampleStruct, rows)
+	rowData := [3][]byte{}
+	columns := []TypeInfo{NativeType{typ: TypeInt}, NativeType{typ: TypeInt}, NativeType{typ: TypeInt}}
+	for idx := 0; idx < rows; idx++ {
+		for col := 0; col < 3; col++ {
+			valLen = dec4ToInt32(data)
+			if valLen > 0 {
+				rowData[col] = data[4:8]
+				data = data[8:]
+			} else {
+				rowData[col] = []byte{}
+				data = data[4:]
+			}
+		}
+		err = Unmarshal(columns[0], rowData[0], &out[idx].Val0)
+		if err != nil {
+			return nil
+		}
+		err = Unmarshal(columns[1], rowData[1], &out[idx].Val1)
+		if err != nil {
+			return nil
+		}
+		err = Unmarshal(columns[2], rowData[2], &out[idx].Val2)
+		if err != nil {
+			return nil
+		}
+	}
+	return out
+}
+
+func newUnmarshal(data []byte, rows int) []row.ExampleStruct {
+	rowSlice := row.ExampleSlice{}
+	writer := row.InitToSliceWriter(&rowSlice, 3)
+	writer.Prepare(int32(rows))
+	write, err := writer.WriteRows(data)
+	if err != nil {
+		return nil
+	}
+	if int(write) != len(data) {
+		panic("wrong write work")
+	}
+	return rowSlice.Rows
+}
+
+func randInts(rows, columns int) []byte {
+	out := make([]byte, 0, rows*columns*8)
+	for i := 0; i < rows*3; i++ {
+		out = append(out, randInt32(rnd, 2147483647, -2147483648)...)
+	}
+	return out
+}
+
+func randInt32(rnd *rand.Rand, max, min int32) []byte {
+	t := rnd.Int31n(4)
+	if t == 0 {
+		return []byte{255, 255, 255, 255}
+	}
+	if t == 1 {
+		return []byte{0, 0, 0, 0}
+	}
+	if max == min {
+		t = max
+	} else {
+		if min < 0 {
+			t = rnd.Int31n(max) + min
+		} else {
+			t = rnd.Int31n(max-min) + min
+		}
+	}
+	return append([]byte{0, 0, 0, 4}, []byte{byte(t >> 24), byte(t >> 16), byte(t >> 8), byte(t)}...)
+}
+
+func dec4ToInt32(data []byte) int32 {
+	return int32(data[0])<<24 | int32(data[1])<<16 | int32(data[2])<<8 | int32(data[3])
+}
+
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/frame.go
+++ b/frame.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/gocql/gocql/pkg/writers"
 )
 
 type unsetColumn struct{}
@@ -476,6 +478,26 @@ func (f *framer) trace() {
 // explicitly enables the custom payload flag
 func (f *framer) payload() {
 	f.flags |= flagCustomPayload
+}
+
+func (f *framer) writeRows(r writers.Rows, rows int) error {
+	r.Prepare(int32(rows))
+	read, err := r.WriteRows(f.buf)
+	f.buf = f.buf[read:]
+	return err
+}
+
+func (f *framer) writeRow(r writers.Rows) error {
+	r.Prepare(int32(1))
+	read, err := r.WriteRow(f.buf)
+	f.buf = f.buf[read:]
+	return err
+}
+
+func (f *framer) writeSolitaryRow(r writers.Row) error {
+	read, err := r.WriteRow(f.buf)
+	f.buf = f.buf[read:]
+	return err
 }
 
 // reads a frame form the wire into the framers buffer
@@ -1746,6 +1768,10 @@ func (f *framer) writeRegisterFrame(streamID int, w *writeRegisterFrame) error {
 	f.writeStringList(w.events)
 
 	return f.finish()
+}
+
+func (f *framer) notEmpty() bool {
+	return len(f.buf) > 0
 }
 
 func (f *framer) readByte() byte {

--- a/pkg/writers/interface.go
+++ b/pkg/writers/interface.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package writers
+
+import "errors"
+
+var NAP = errors.New("write operation is completed, but there is still data left")
+
+type Struct interface {
+	UnmarshalCQL2(data []byte) int32
+}
+
+// Rows describes interaction between callers and Rows`s designed for row by row write.
+// Rows useful if expect response with undefined rows count and callers fill the data gradual.
+// Callers must call call Prepare(n) before call WriteRow n times and/or before WriteRows call.
+// Implementations must not modify the slice data, even temporarily and not retain data.
+type Rows interface {
+	// Prepare helps inform Rows`s about count of rows that callers have. So callers can help Rows`s have better resource pre allocation.
+	Prepare(rows int32)
+	// WriteRow write a single row.
+	// If write is done and len(data)>w must return error=nil.
+	// If data is not enough to write a row must return io.ErrUnexpectedEOF
+	WriteRow(data []byte) (w int32, err error)
+	// WriteRows write all rows from data.
+	// If write is not done or is partial done because data not enough must return io.ErrUnexpectedEOF
+	WriteRows(data []byte) (w int32, err error)
+	ColumnsInRow() int
+}
+
+// Row describes interaction between callers and writers designed for solitary row write.
+// Row useful if expect response with rows=1 or 0.
+// Implementations must not modify the slice data, even temporarily and not retain data.
+type Row interface {
+	// WriteRow write a single row.
+	// If write is done and len(data)>w must return error=nil.
+	// If data is not enough to write a row must return io.ErrUnexpectedEOF
+	WriteRow(data []byte) (write int32, err error)
+	ColumnsInRow() int
+}
+
+// Slice describes interaction between Rows and go slices (actually structures with slices).
+// Rows must raise code from any panic due UnmarshalElem calls and call OnElemError.
+// Implementations must not modify the slice data, even temporarily and not retain data.
+// On wrong data cases implementations must use panic with detailed description.
+// Implementations must independently monitor the sufficiency of the slice length.
+type Slice interface {
+	// Init same as ...make(slice,count).
+	Init(count int32)
+	// Append same as build in append func.
+	Append(count int32)
+	// UnmarshalElem writes data to slice elem, returns write bites count.
+	UnmarshalElem(data []byte) int32
+	// NextElem switch Slice to next elem.
+	NextElem()
+	// OnElemError helps ToSliceWriter tell to Slice about panic due UnmarshalElem call.
+	OnElemError()
+	// CutOnDone helps Slice to free pre allocated resources due all Expand and Init calls.
+	CutOnDone()
+	// Len returns current Slice len.
+	Len() int
+}
+
+// Map describes interaction between Rows and go maps.
+// Rows must raise code from any panic due UnmarshalMapElem calls and call OnMapElemError.
+// Implementations must not modify the slice data, even temporarily and not retain data.
+// On wrong data cases implementations must use panic with detailed description.
+type Map interface {
+	// UnmarshalMapElem writes data to map elem, returns write bites count.
+	UnmarshalMapElem(data []byte) int32
+	// OnMapElemError helps ToMapWriter tell to Map about panic due UnmarshalMapElem call.
+	OnMapElemError()
+}

--- a/pkg/writers/row/bench_anti_panic_test.go
+++ b/pkg/writers/row/bench_anti_panic_test.go
@@ -1,0 +1,136 @@
+// nolint
+package row
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func BenchmarkAntiPanicOrCheckLen_test(b *testing.B) {
+	runAntiPanicSet(500000, b)
+	runAntiPanicSet(500, b)
+	runAntiPanicSet(50, b)
+}
+
+func runAntiPanicSet(bytesLen int, b *testing.B) {
+	setName := fmt.Sprintf("framer len %d", bytesLen)
+	data := randBytes(bytesLen)
+	b.Run(setName, func(b *testing.B) {
+		fmt.Println("--------------------------------------", setName, "---------------------------------------")
+		runReadWith("          read2If4", read2If4, data, b)
+		runReadWith("read2WithAntiPanic", read2WithAntiPanic, data, b)
+		runReadWith("     read4WithIf10", read4WithIf10, data, b)
+		runReadWith("read4WithAntiPanic", read4WithAntiPanic, data, b)
+	})
+}
+
+func runReadWith(name string, rFunc func([]byte), data []byte, b *testing.B) {
+	b.Run(name, func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rFunc(data)
+		}
+	})
+}
+
+//go:noinline
+func read2If4(data []byte) {
+	elems := len(data) / 4
+	tmp := int16(0)
+	var err error
+	for idx := 0; idx < elems; idx++ {
+		tmp, err = dec2ToInt16Err(data)
+		if err != nil {
+			return
+		}
+		data = data[2:]
+		tmp, err = dec2ToInt16Err(data)
+		if err != nil {
+			return
+		}
+		data = data[2:]
+		_ = tmp
+	}
+}
+
+//go:noinline
+func read2WithAntiPanic(data []byte) {
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%s", errF), "runtime error: index out of range") {
+				return
+			}
+		}
+	}()
+	elems := len(data) / 4
+	tmp := int16(0)
+	for idx := 0; idx < elems; idx++ {
+		tmp = dec2ToInt16(data)
+		data = data[2:]
+		tmp = dec2ToInt16(data)
+		data = data[2:]
+		_ = tmp
+	}
+}
+
+//go:noinline
+func read4WithIf10(data []byte) {
+	elems := len(data) / 4
+	tmp := int16(0)
+	var err error
+	for idx := 0; idx < elems; idx++ {
+		tmp, err = twiceDec2ToInt16Err(data)
+		if err != nil {
+			return
+		}
+		data = data[4:]
+		tmp, err = twiceDec2ToInt16Err(data)
+		if err != nil {
+			return
+		}
+		data = data[4:]
+		_ = tmp
+	}
+}
+
+//go:noinline
+func read4WithAntiPanic(data []byte) {
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%s", errF), "runtime error: index out of range") {
+				return
+			}
+		}
+	}()
+	elems := len(data) / 8
+	tmp := int16(0)
+	for idx := 0; idx < elems; idx++ {
+		tmp = twiceDec2ToInt16(data)
+		data = data[4:]
+		tmp = twiceDec2ToInt16(data)
+		data = data[4:]
+		_ = tmp
+	}
+}
+
+func twiceDec2ToInt16Err(data []byte) (int16, error) {
+	tmp, err := dec2ToInt16Err(data)
+	if err != nil {
+		return 0, err
+	}
+	data = data[2:]
+	tmp, err = dec2ToInt16Err(data)
+	if err != nil {
+		return 0, err
+	}
+	data = data[2:]
+	return tmp, nil
+}
+
+func twiceDec2ToInt16(data []byte) int16 {
+	tmp := dec2ToInt16(data)
+	data = data[2:]
+	tmp = dec2ToInt16(data)
+	data = data[2:]
+	return tmp
+}

--- a/pkg/writers/row/example_map.go
+++ b/pkg/writers/row/example_map.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+type ExampleMap map[int32]ExampleStruct
+
+func (s ExampleMap) UnmarshalMapElem(data []byte) int32 {
+	tmp := ExampleStruct{}
+	write := tmp.UnmarshalCQL2(data)
+	s[tmp.GetID()] = tmp
+	return write
+}
+
+func (s ExampleMap) OnMapElemError() {
+}
+
+type ExampleMapRefs map[int32]ExampleStruct
+
+func (s *ExampleMapRefs) UnmarshalMapElem(data []byte) int32 {
+	tmp := ExampleStruct{}
+	write := tmp.UnmarshalCQL2(data)
+	(*s)[tmp.GetID()] = tmp
+	return write
+}
+
+func (s *ExampleMapRefs) OnMapElemError() {
+}
+
+type ExampleRefMap map[int32]*ExampleStruct
+
+func (s ExampleRefMap) UnmarshalMapElem(data []byte) int32 {
+	tmp := ExampleStruct{}
+	write := tmp.UnmarshalCQL2(data)
+	s[tmp.GetID()] = &tmp
+	return write
+}
+
+func (s ExampleRefMap) OnMapElemError() {
+}
+
+type ExamplesRefMapRefs map[int32]*ExampleStruct
+
+func (s *ExamplesRefMapRefs) UnmarshalMapElem(data []byte) int32 {
+	tmp := ExampleStruct{}
+	write := tmp.UnmarshalCQL2(data)
+	(*s)[tmp.GetID()] = &tmp
+	return write
+}
+func (s *ExamplesRefMapRefs) OnMapElemError() {
+}

--- a/pkg/writers/row/example_ref_slice.go
+++ b/pkg/writers/row/example_ref_slice.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+// ExampleRefSlice represent example implemented Slice interface with processing by reference of slice for slice.
+// Comparison of slice processing in various ways you can see in bench_slice_test.go.
+type ExampleRefSlice struct {
+	rows   *[]ExampleStruct
+	rowIdx int
+}
+
+func (s *ExampleRefSlice) ReUse(rows *[]ExampleStruct) {
+	s.rowIdx = 0
+	s.rows = rows
+}
+
+func (s *ExampleRefSlice) Init(count int32) {
+	*s.rows = make([]ExampleStruct, count)
+}
+
+func (s *ExampleRefSlice) Append(count int32) {
+	*s.rows = append(*s.rows, make([]ExampleStruct, count)...)
+}
+
+func (s *ExampleRefSlice) UnmarshalElem(data []byte) int32 {
+	if s.rowIdx > s.Len()-1 {
+		s.Append(1)
+	}
+	return (*s.rows)[s.rowIdx].UnmarshalCQL2(data)
+}
+
+func (s *ExampleRefSlice) NextElem() {
+	s.rowIdx++
+}
+
+func (s *ExampleRefSlice) OnElemError() {
+	(*s.rows)[s.rowIdx] = *new(ExampleStruct)
+}
+
+func (s *ExampleRefSlice) CutOnDone() {
+	if s.rowIdx+1 < s.Len() {
+		*s.rows = (*s.rows)[:s.rowIdx+1]
+	}
+}
+
+func (s *ExampleRefSlice) Len() int {
+	return len(*s.rows)
+}

--- a/pkg/writers/row/example_ref_slice_refs.go
+++ b/pkg/writers/row/example_ref_slice_refs.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+// ExampleRefSliceRefs represent example implemented Slice interface with processing by reference of slice for slice of references.
+// Comparison of slice processing in various ways you can see in bench_slice_test.go.
+type ExampleRefSliceRefs struct {
+	rows   *[]*ExampleStruct
+	rowIdx int
+}
+
+func (s *ExampleRefSliceRefs) ReUse(rows *[]*ExampleStruct) {
+	s.rowIdx = 0
+	s.rows = rows
+}
+
+func (s *ExampleRefSliceRefs) Init(count int32) {
+	*s.rows = make([]*ExampleStruct, count)
+}
+
+func (s *ExampleRefSliceRefs) Append(count int32) {
+	*s.rows = append(*s.rows, make([]*ExampleStruct, count)...)
+}
+
+func (s *ExampleRefSliceRefs) UnmarshalElem(data []byte) int32 {
+	if s.rowIdx > s.Len()-1 {
+		s.Append(1)
+	}
+	(*s.rows)[s.rowIdx] = &ExampleStruct{}
+	return (*s.rows)[s.rowIdx].UnmarshalCQL2(data)
+}
+
+func (s *ExampleRefSliceRefs) NextElem() {
+	s.rowIdx++
+}
+
+func (s *ExampleRefSliceRefs) OnElemError() {
+	(*s.rows)[s.rowIdx] = new(ExampleStruct)
+}
+
+func (s *ExampleRefSliceRefs) CutOnDone() {
+	if s.rowIdx+1 < s.Len() {
+		*s.rows = (*s.rows)[:s.rowIdx+1]
+	}
+}
+
+func (s *ExampleRefSliceRefs) Len() int {
+	return len(*s.rows)
+}

--- a/pkg/writers/row/example_slice.go
+++ b/pkg/writers/row/example_slice.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+// ExampleSlice represent example implemented Slice interface with direct slice processing for slice.
+// Comparison of slice processing in various ways you can see in bench_slice_test.go.
+type ExampleSlice struct {
+	Rows   []ExampleStruct
+	rowIdx int
+}
+
+func (s *ExampleSlice) Init(count int32) {
+	s.rowIdx = 0
+	s.Rows = make([]ExampleStruct, count)
+}
+
+func (s *ExampleSlice) Append(count int32) {
+	s.Rows = append(s.Rows, make([]ExampleStruct, count)...)
+}
+
+func (s *ExampleSlice) UnmarshalElem(data []byte) int32 {
+	if s.rowIdx > s.Len()-1 {
+		s.Append(1)
+	}
+	return s.Rows[s.rowIdx].UnmarshalCQL2(data)
+}
+
+func (s *ExampleSlice) NextElem() {
+	s.rowIdx++
+}
+
+func (s *ExampleSlice) OnElemError() {
+	s.Rows[s.rowIdx] = *new(ExampleStruct)
+}
+
+func (s *ExampleSlice) CutOnDone() {
+	if s.rowIdx+1 < s.Len() {
+		s.Rows = s.Rows[:s.rowIdx+1]
+	}
+}
+
+func (s *ExampleSlice) Len() int {
+	return len(s.Rows)
+}

--- a/pkg/writers/row/example_slice_refs.go
+++ b/pkg/writers/row/example_slice_refs.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+// ExampleSliceRefs represent example implemented Slice interface with direct slice processing for slice of references.
+// Comparison of slice processing in various ways you can see in bench_slice_test.go.
+type ExampleSliceRefs struct {
+	Rows   []*ExampleStruct
+	rowIdx int
+}
+
+func (s *ExampleSliceRefs) Init(count int32) {
+	s.rowIdx = 0
+	s.Rows = make([]*ExampleStruct, count)
+}
+
+func (s *ExampleSliceRefs) Append(count int32) {
+	s.Rows = append(s.Rows, make([]*ExampleStruct, count)...)
+}
+
+func (s *ExampleSliceRefs) UnmarshalElem(data []byte) int32 {
+	if s.rowIdx > s.Len()-1 {
+		s.Append(1)
+	}
+	s.Rows[s.rowIdx] = &ExampleStruct{}
+	return s.Rows[s.rowIdx].UnmarshalCQL2(data)
+}
+
+func (s *ExampleSliceRefs) NextElem() {
+	s.rowIdx++
+}
+
+func (s *ExampleSliceRefs) OnElemError() {
+	*s.Rows[s.rowIdx] = *new(ExampleStruct)
+}
+
+func (s *ExampleSliceRefs) CutOnDone() {
+	if s.rowIdx+1 < s.Len() {
+		s.Rows = s.Rows[:s.rowIdx+1]
+	}
+}
+
+func (s *ExampleSliceRefs) Len() int {
+	return len(s.Rows)
+}

--- a/pkg/writers/row/example_struct.go
+++ b/pkg/writers/row/example_struct.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+import (
+	"fmt"
+)
+
+type ExampleStruct struct {
+	Val0 int32
+	Val1 int32
+	Val2 int32
+}
+
+func (e *ExampleStruct) UnmarshalCQL2(data []byte) int32 {
+	write := int32(0)
+	elemLen := int32(0)
+	e.Val0, write = decodeIntToInt32(data[:8])
+	e.Val1, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	e.Val2, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	return write
+}
+
+func unmarshalToExample(e *ExampleStruct, data []byte) int32 {
+	write := int32(0)
+	elemLen := int32(0)
+	e.Val0, write = decodeIntToInt32(data[:8])
+	e.Val1, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	e.Val2, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	return write
+}
+
+func unmarshalExample(data []byte) (int32, ExampleStruct) {
+	out := ExampleStruct{}
+	write := int32(0)
+	elemLen := int32(0)
+	out.Val0, write = decodeIntToInt32(data[:8])
+	out.Val1, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	out.Val2, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	return write, out
+}
+
+func unmarshalRefExample(data []byte) (int32, *ExampleStruct) {
+	out := ExampleStruct{}
+	write := int32(0)
+	elemLen := int32(0)
+	out.Val0, write = decodeIntToInt32(data[:8])
+	out.Val1, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	out.Val2, elemLen = decodeIntToInt32(data[write : write+8])
+	write += elemLen
+	return write, &out
+}
+
+func (e *ExampleStruct) GetID() int32 {
+	return e.Val0
+}
+
+func decodeIntToInt32(data []byte) (out int32, read int32) {
+	valueLen := dec4ToInt32(data[:4])
+	switch {
+	case valueLen == 4:
+		return dec4ToInt32(data[4:8]), 8
+	case valueLen <= 0:
+		return int32(0), 4
+	default:
+		panic(fmt.Sprintf("wrong value len <int> type should:4 have:%d, data:%v", valueLen, data[:8]))
+	}
+}
+
+func dec4ToInt32(data []byte) int32 {
+	return int32(data[0])<<24 | int32(data[1])<<16 | int32(data[2])<<8 | int32(data[3])
+}

--- a/pkg/writers/row/utils.go
+++ b/pkg/writers/row/utils.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+)
+
+func dec2ToInt16Err(data []byte) (int16, error) {
+	if len(data) < 2 {
+		return 0, errors.New("low len")
+	}
+	return int16(data[0])<<8 | int16(data[1]), nil
+}
+
+func dec2ToInt16(data []byte) int16 {
+	return int16(data[0])<<8 | int16(data[1])
+}
+
+func randBytes(bytesLen int) []byte {
+	out := make([]byte, bytesLen)
+	for idx := range out {
+		out[idx] = byte(rnd.Intn(256))
+	}
+	return out
+}
+
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/writers/row/writer_map.go
+++ b/pkg/writers/row/writer_map.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+import (
+	"fmt"
+	"github.com/gocql/gocql/pkg/writers"
+	"io"
+	"strings"
+)
+
+func InitToMapWriter(rows writers.Map, columnsInRow int) writers.Rows {
+	return &ToMapWriter{
+		rows:    rows,
+		columns: columnsInRow,
+	}
+}
+
+// ToMapWriter it`s implementation of writers.Rows interface, designed for write rows to the Map`s.
+type ToMapWriter struct {
+	rows    writers.Map
+	columns int
+}
+
+func (r *ToMapWriter) ColumnsInRow() int {
+	return r.columns
+}
+
+func (r *ToMapWriter) Prepare(_ int32) {
+}
+
+func (r *ToMapWriter) ReUse(rows writers.Map) {
+	r.rows = rows
+}
+
+func (r *ToMapWriter) WriteRow(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+			r.rows.OnMapElemError()
+		}
+	}()
+	write = r.rows.UnmarshalMapElem(data)
+	return
+}
+
+func (r *ToMapWriter) WriteRows(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+			r.rows.OnMapElemError()
+		}
+	}()
+	for int(write) < len(data) {
+		write += r.rows.UnmarshalMapElem(data[write:])
+	}
+	return
+}

--- a/pkg/writers/row/writer_slice.go
+++ b/pkg/writers/row/writer_slice.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row
+
+import (
+	"fmt"
+	"github.com/gocql/gocql/pkg/writers"
+	"io"
+	"strings"
+)
+
+func InitToSliceWriter(rows writers.Slice, columnsInRow int) ToSliceWriter {
+	return ToSliceWriter{
+		rows:    rows,
+		columns: columnsInRow,
+	}
+}
+
+// ToSliceWriter it`s implementation of writers.Rows interface, designed for write rows to the Slice`s.
+type ToSliceWriter struct {
+	rows    writers.Slice
+	columns int
+}
+
+func (r *ToSliceWriter) ColumnsInRow() int {
+	return r.columns
+}
+
+func (r *ToSliceWriter) ReUse(rows writers.Slice) {
+	r.rows = rows
+}
+
+func (r *ToSliceWriter) Prepare(rows int32) {
+	if rows == 0 {
+		return
+	}
+	if r.rows.Len() < 1 {
+		r.rows.Init(rows)
+	}
+	r.rows.Append(rows)
+}
+
+func (r *ToSliceWriter) WriteRow(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+			r.rows.OnElemError()
+		}
+	}()
+	write = r.rows.UnmarshalElem(data)
+	r.rows.NextElem()
+	return
+}
+
+func (r *ToSliceWriter) WriteRows(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+			r.rows.OnElemError()
+		}
+	}()
+	for int(write) < len(data) {
+		write += r.rows.UnmarshalElem(data[write:])
+		r.rows.NextElem()
+	}
+	return
+}

--- a/pkg/writers/row_gen/go.mod
+++ b/pkg/writers/row_gen/go.mod
@@ -1,0 +1,3 @@
+module github.com/gocql/pkg/writers/row_gen
+
+go 1.18

--- a/pkg/writers/row_gen/writer_ref_slice.go
+++ b/pkg/writers/row_gen/writer_ref_slice.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row_gen
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type WriteToFunc[V any] func(val *V, data []byte) int32
+
+func InitRefSliceWriter[V any](rows *[]V, writer WriteToFunc[V], columnsInRow int) ToSliceWriter[V] {
+	return ToSliceWriter[V]{
+		write:   writer,
+		rows:    rows,
+		columns: columnsInRow,
+	}
+}
+
+// ToSliceWriter it`s implementation of writers.RowsWriter interface, designed for write rows to the go slices.
+type ToSliceWriter[V any] struct {
+	write   WriteToFunc[V]
+	rows    *[]V
+	rowIdx  int
+	columns int
+}
+
+func (r *ToSliceWriter[V]) ColumnsInRow() int {
+	return r.columns
+}
+
+func (r *ToSliceWriter[V]) Prepare(rows int32) {
+	if rows == 0 {
+		return
+	}
+	if len(*r.rows) < 1 {
+		*r.rows = make([]V, rows)
+	}
+	*r.rows = append(*r.rows, make([]V, rows)...)
+}
+
+func (r *ToSliceWriter[V]) CutOnDone() {
+	if r.rowIdx+1 < len(*r.rows) {
+		*r.rows = (*r.rows)[:r.rowIdx+1]
+	}
+}
+
+func (r *ToSliceWriter[V]) ReUse(rows *[]V) {
+	r.rows = rows
+	r.rowIdx = 0
+}
+
+func (r *ToSliceWriter[V]) WriteRow(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+			(*r.rows)[r.rowIdx] = *new(V)
+		}
+	}()
+	if r.rowIdx > len(*r.rows)-1 {
+		*r.rows = append(*r.rows, *new(V))
+	}
+	write = r.write(&(*r.rows)[r.rowIdx], data)
+	r.rowIdx++
+	return
+}
+
+func (r *ToSliceWriter[V]) WriteRows(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+			(*r.rows)[r.rowIdx] = *new(V)
+		}
+	}()
+	for int(write) < len(data) {
+		if r.rowIdx > len(*r.rows)-1 {
+			*r.rows = append(*r.rows, *new(V))
+		}
+		write += r.write(&(*r.rows)[r.rowIdx], data[write:])
+		r.rowIdx++
+	}
+	return
+}

--- a/pkg/writers/row_gen/writer_ref_slice_ref.go
+++ b/pkg/writers/row_gen/writer_ref_slice_ref.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package row_gen
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type InitFunc[V any] func() V
+
+func InitRefSliceRefsWriter[V any](rows *[]*V, writer WriteToFunc[V], columnsInRow int) ToSliceRefsWriter[V] {
+	return ToSliceRefsWriter[V]{
+		write:   writer,
+		rows:    rows,
+		columns: columnsInRow,
+	}
+}
+
+// ToSliceRefsWriter it`s implementation of writers.RowsWriter interface, designed for write rows to the go slices of references.
+type ToSliceRefsWriter[V any] struct {
+	write     WriteToFunc[V]
+	rows      *[]*V
+	rowIdx    int
+	minRowLen int
+	columns   int
+}
+
+func (r *ToSliceRefsWriter[V]) ColumnsInRow() int {
+	return r.columns
+}
+
+func (r *ToSliceRefsWriter[V]) Prepare(rows int32) {
+	if rows == 0 {
+		return
+	}
+	if len(*r.rows) < 1 {
+		*r.rows = make([]*V, rows)
+	}
+	*r.rows = append(*r.rows, make([]*V, rows)...)
+}
+
+func (r *ToSliceRefsWriter[V]) CutOnDone() {
+	if r.rowIdx+1 < len(*r.rows) {
+		*r.rows = (*r.rows)[:r.rowIdx+1]
+	}
+}
+
+func (r *ToSliceRefsWriter[V]) ReUse(rows *[]*V) {
+	r.rows = rows
+	r.rowIdx = 0
+}
+
+func (r *ToSliceRefsWriter[V]) WriteRow(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+		}
+	}()
+	if r.rowIdx > len(*r.rows)-1 {
+		*r.rows = append(*r.rows, new(V))
+	} else {
+		(*r.rows)[r.rowIdx] = new(V)
+	}
+	write = r.write((*r.rows)[r.rowIdx], data)
+	r.rowIdx++
+	return
+}
+
+func (r *ToSliceRefsWriter[V]) WriteRows(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+		}
+	}()
+	for int(write) < len(data) {
+		if r.rowIdx > len(*r.rows)-1 {
+			*r.rows = append(*r.rows, new(V))
+		} else {
+			(*r.rows)[r.rowIdx] = new(V)
+		}
+		write += r.write((*r.rows)[r.rowIdx], data[write:])
+		r.rowIdx++
+	}
+	return
+}

--- a/pkg/writers/solo_row/interface.go
+++ b/pkg/writers/solo_row/interface.go
@@ -1,0 +1,5 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package solo_row

--- a/pkg/writers/solo_row/solo_ref.go
+++ b/pkg/writers/solo_row/solo_ref.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package solo_row
+
+import (
+	"fmt"
+	"github.com/gocql/gocql/pkg/writers"
+	"io"
+	"strings"
+)
+
+func InitSoloRefWriter(rowRef writers.Struct, columnsInRow int) ToStruct {
+	return ToStruct{
+		row:     rowRef,
+		columns: columnsInRow,
+	}
+}
+
+// ToStruct optimized for responses with only one row.
+// implement Row
+type ToStruct struct {
+	row     writers.Struct
+	columns int
+}
+
+func (r *ToStruct) ColumnsInRow() int {
+	return r.columns
+}
+
+// ReUse puts new reference into scanner. Useful for scanner reuse.
+func (r *ToStruct) ReUse(rowRef writers.Struct) {
+	r.row = rowRef
+}
+
+func (r *ToStruct) WriteRow(data []byte) (write int32, err error) {
+	// In usual case don`t need to check data on every read operation, because if unmarshalers already tested and data r right we should just read.
+	// In case wrong data or wrong unmarshaler will result to wrong all rows in response, that`s why we can just catch panic once and make error.
+	defer func() {
+		if errF := recover(); errF != nil {
+			if strings.Contains(fmt.Sprintf("%T", errF), "runtime.boundsError") {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = fmt.Errorf("%s", errF)
+			}
+		}
+	}()
+	write = r.row.UnmarshalCQL2(data)
+	return
+}


### PR DESCRIPTION
As part of #1720
Main changes:
1) Added Row and Rows interfaces for rows writers.
Now users can write rows data directly from raw to any abstractions.
Interfaces design like io.Writer interface, with corrections for better processing with db rows.
2) Added implementations for Row and Rows writers.
One - for write rows to go slice`s through Slice interface. 
Second - for write rows to go map`s through Map interface. 
And two more for write rows to go slice`s by generics.
3) Added one implementation for Row writer. 
For write solidarity row to solidarity abstraction.
4) Added Slice and Map interfaces for connect Rows writers with different types of go slice`s and go map`s.
5) Added Iter methods for use Row and Rows writers.
