### PR TITLE
Allowed implementation of HostSelectionPolicy outside the gocql pkg

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,3 +141,4 @@ Dmitry Kropachev <dmitry.kropachev@gmail.com>
 Oliver Boyle <pleasedontspamme4321+gocql@gmail.com>
 Jackson Fleming <jackson.fleming@instaclustr.com>
 Sylwia Szunejko <sylwia.szunejko@scylladb.com>
+Bohdan Siryk <bohdan.siryk00@gmail.com>

--- a/host_source.go
+++ b/host_source.go
@@ -897,3 +897,51 @@ func (b *errorBroadcaster) stop() {
 	}
 	b.listeners = nil
 }
+
+// NewHostInfo is created for testing purposes when you need to mock HostInfo to test your own implementation of
+// HostSelectionPolicy, HostFilter etc.
+func NewHostInfo(
+	hostname string,
+	peer net.IP,
+	broadcastAddress net.IP,
+	listenAddress net.IP,
+	rpcAddress net.IP,
+	preferredIP net.IP,
+	connectAddress net.IP,
+	port int,
+	dataCenter string,
+	rack string,
+	hostId string,
+	workload string,
+	graph bool,
+	dseVersion string,
+	partitioner string,
+	clusterName string,
+	version cassVersion,
+	state nodeState,
+	schemaVersion string,
+	tokens []string,
+) *HostInfo {
+	return &HostInfo{
+		hostname:         hostname,
+		peer:             peer,
+		broadcastAddress: broadcastAddress,
+		listenAddress:    listenAddress,
+		rpcAddress:       rpcAddress,
+		preferredIP:      preferredIP,
+		connectAddress:   connectAddress,
+		port:             port,
+		dataCenter:       dataCenter,
+		rack:             rack,
+		hostId:           hostId,
+		workload:         workload,
+		graph:            graph,
+		dseVersion:       dseVersion,
+		partitioner:      partitioner,
+		clusterName:      clusterName,
+		version:          version,
+		state:            state,
+		schemaVersion:    schemaVersion,
+		tokens:           tokens,
+	}
+}

--- a/policies.go
+++ b/policies.go
@@ -286,7 +286,7 @@ type HostSelectionPolicy interface {
 	// Multiple attempts of a single query execution won't call the returned NextHost function concurrently,
 	// so it's safe to have internal state without additional synchronization as long as every call to Pick returns
 	// a different instance of NextHost.
-	Pick(ExecutableQuery) NextHost
+	Pick(PickableQuery) NextHost
 }
 
 // SelectedHost is an interface returned when picking a host from a host
@@ -323,7 +323,7 @@ func (r *roundRobinHostPolicy) KeyspaceChanged(KeyspaceUpdateEvent) {}
 func (r *roundRobinHostPolicy) SetPartitioner(partitioner string)   {}
 func (r *roundRobinHostPolicy) Init(*Session)                       {}
 
-func (r *roundRobinHostPolicy) Pick(qry ExecutableQuery) NextHost {
+func (r *roundRobinHostPolicy) Pick(qry PickableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&r.lastUsedHostIdx, 1)
 	return roundRobbin(int(nextStartOffset), r.hosts.get())
 }
@@ -558,7 +558,7 @@ func (m *clusterMeta) resetTokenRing(partitioner string, hosts []*HostInfo, logg
 	m.tokenRing = tokenRing
 }
 
-func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
+func (t *tokenAwareHostPolicy) Pick(qry PickableQuery) NextHost {
 	if qry == nil {
 		return t.fallback.Pick(qry)
 	}
@@ -762,7 +762,7 @@ func (r *hostPoolHostPolicy) HostDown(host *HostInfo) {
 	r.RemoveHost(host)
 }
 
-func (r *hostPoolHostPolicy) Pick(qry ExecutableQuery) NextHost {
+func (r *hostPoolHostPolicy) Pick(qry PickableQuery) NextHost {
 	return func() SelectedHost {
 		r.mu.RLock()
 		defer r.mu.RUnlock()
@@ -894,7 +894,7 @@ func roundRobbin(shift int, hosts ...[]*HostInfo) NextHost {
 	}
 }
 
-func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
+func (d *dcAwareRR) Pick(q PickableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
 	return roundRobbin(int(nextStartOffset), d.localHosts.get(), d.remoteHosts.get())
 }
@@ -956,7 +956,7 @@ func (d *rackAwareRR) RemoveHost(host *HostInfo) {
 func (d *rackAwareRR) HostUp(host *HostInfo)   { d.AddHost(host) }
 func (d *rackAwareRR) HostDown(host *HostInfo) { d.RemoveHost(host) }
 
-func (d *rackAwareRR) Pick(q ExecutableQuery) NextHost {
+func (d *rackAwareRR) Pick(q PickableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
 	return roundRobbin(int(nextStartOffset), d.hosts[0].get(), d.hosts[1].get(), d.hosts[2].get())
 }

--- a/query_executor.go
+++ b/query_executor.go
@@ -13,14 +13,17 @@ type ExecutableQuery interface {
 	attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
 	speculativeExecutionPolicy() SpeculativeExecutionPolicy
-	GetRoutingKey() ([]byte, error)
-	Keyspace() string
 	Table() string
 	IsIdempotent() bool
-
 	withContext(context.Context) ExecutableQuery
 
+	PickableQuery
 	RetryableQuery
+}
+
+type PickableQuery interface {
+	GetRoutingKey() ([]byte, error)
+	Keyspace() string
 }
 
 type queryExecutor struct {


### PR DESCRIPTION
This PR allows implementation of `HostSelectionPolicy` interface outside the gocql package. 
Also, it adds `NewHostInfo` constructor for testing purposes. We need this because `HostSelectionPolicy`, `HostFilter`, and other options of ClusterConfig are presented as a public interface so they may be implemented outside the gocql package. But those custom implementations cannot be tested, because all fields of `HostInfo` are private and protected from concurrent changes by mutex. 

closes #1759