### PR TITLE
CASSGO-24 Remove global logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change Batch API to be consistent with Query() (CASSGO-7)
 
+- Remove deprecated global logger (CASSGO-24)
+
 ### Fixed
 
 - Retry policy now takes into account query idempotency (CASSGO-27)

--- a/cluster.go
+++ b/cluster.go
@@ -260,7 +260,7 @@ type ClusterConfig struct {
 	HostDialer HostDialer
 
 	// Logger for this ClusterConfig.
-	// If not specified, defaults to the global gocql.Logger.
+	// If not specified, defaults to the gocql.defaultLogger.
 	Logger StdLogger
 
 	// internal config for testing
@@ -304,7 +304,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 
 func (cfg *ClusterConfig) logger() StdLogger {
 	if cfg.Logger == nil {
-		return Logger
+		return &defaultLogger{}
 	}
 	return cfg.Logger
 }

--- a/conn.go
+++ b/conn.go
@@ -151,7 +151,7 @@ type ConnConfig struct {
 
 func (c *ConnConfig) logger() StdLogger {
 	if c.Logger == nil {
-		return Logger
+		return &defaultLogger{}
 	}
 	return c.Logger
 }

--- a/logger.go
+++ b/logger.go
@@ -58,7 +58,3 @@ type defaultLogger struct{}
 func (l *defaultLogger) Print(v ...interface{})                 { log.Print(v...) }
 func (l *defaultLogger) Printf(format string, v ...interface{}) { log.Printf(format, v...) }
 func (l *defaultLogger) Println(v ...interface{})               { log.Println(v...) }
-
-// Logger for logging messages.
-// Deprecated: Use ClusterConfig.Logger instead.
-var Logger StdLogger = &defaultLogger{}


### PR DESCRIPTION
This PR removes the global instance of the logger. For now, if the logger in the cluster config is not set, the new approach will set a new instance of the default logger for each session.
Issue: #1766