### PR TITLE
CASSGO-12 Remove deprecated features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't restrict server authenticator unless PasswordAuthentictor.AllowedAuthenticators is provided (CASSGO-19)
 
+- Cleanup of deprecated elements (CASSGO-12)
+
 - Remove global NewBatch function (CASSGO-15)
 
 ### Fixed

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -45,7 +45,7 @@ import (
 	"time"
 	"unicode"
 
-	inf "gopkg.in/inf.v0"
+	"gopkg.in/inf.v0"
 )
 
 func TestEmptyHosts(t *testing.T) {
@@ -2273,45 +2273,6 @@ func TestGetColumnMetadata(t *testing.T) {
 	}
 }
 
-func TestViewMetadata(t *testing.T) {
-	session := createSession(t)
-	defer session.Close()
-	createViews(t, session)
-
-	views, err := getViewsMetadata(session, "gocql_test")
-	if err != nil {
-		t.Fatalf("failed to query view metadata with err: %v", err)
-	}
-	if views == nil {
-		t.Fatal("failed to query view metadata, nil returned")
-	}
-
-	if len(views) != 1 {
-		t.Fatal("expected one view")
-	}
-
-	textType := TypeText
-	if flagCassVersion.Before(3, 0, 0) {
-		textType = TypeVarchar
-	}
-
-	expectedView := ViewMetadata{
-		Keyspace:   "gocql_test",
-		Name:       "basicview",
-		FieldNames: []string{"birthday", "nationality", "weight", "height"},
-		FieldTypes: []TypeInfo{
-			NativeType{typ: TypeTimestamp},
-			NativeType{typ: textType},
-			NativeType{typ: textType},
-			NativeType{typ: textType},
-		},
-	}
-
-	if !reflect.DeepEqual(views[0], expectedView) {
-		t.Fatalf("view is %+v, but expected %+v", views[0], expectedView)
-	}
-}
-
 func TestMaterializedViewMetadata(t *testing.T) {
 	if flagCassVersion.Before(3, 0, 0) {
 		return
@@ -2593,11 +2554,6 @@ func TestKeyspaceMetadata(t *testing.T) {
 	}
 	if aggregate.StateFunc.Name != "avgstate" {
 		t.Fatalf("expected state function %s, but got %s", "avgstate", aggregate.StateFunc.Name)
-	}
-
-	_, found = keyspaceMetadata.Views["basicview"]
-	if !found {
-		t.Fatal("failed to find the view in metadata")
 	}
 	_, found = keyspaceMetadata.UserTypes["basicview"]
 	if !found {

--- a/conn.go
+++ b/conn.go
@@ -166,14 +166,6 @@ func (fn connErrorHandlerFn) HandleError(conn *Conn, err error, closed bool) {
 	fn(conn, err, closed)
 }
 
-// If not zero, how many timeouts we will allow to occur before the connection is closed
-// and restarted. This is to prevent a single query timeout from killing a connection
-// which may be serving more queries just fine.
-// Default is 0, should not be changed concurrently with queries.
-//
-// Deprecated.
-var TimeoutLimit int64 = 0
-
 // Conn is a single connection to a Cassandra node. It can be used to execute
 // queries, but users are usually advised to use a more reliable, higher
 // level API.
@@ -764,7 +756,7 @@ func (c *Conn) releaseStream(call *callReq) {
 }
 
 func (c *Conn) handleTimeout() {
-	if TimeoutLimit > 0 && atomic.AddInt64(&c.timeouts, 1) > TimeoutLimit {
+	if atomic.AddInt64(&c.timeouts, 1) > 0 {
 		c.closeWithError(ErrTooManyTimeouts)
 	}
 }

--- a/frame.go
+++ b/frame.go
@@ -275,17 +275,6 @@ func ParseConsistencyWrapper(s string) (consistency Consistency, err error) {
 	return
 }
 
-// MustParseConsistency is the same as ParseConsistency except it returns
-// an error (never). It is kept here since breaking changes are not good.
-// DEPRECATED: use ParseConsistency if you want a panic on parse error.
-func MustParseConsistency(s string) (Consistency, error) {
-	c, err := ParseConsistencyWrapper(s)
-	if err != nil {
-		panic(err)
-	}
-	return c, nil
-}
-
 type SerialConsistency uint16
 
 const (

--- a/marshal.go
+++ b/marshal.go
@@ -2455,14 +2455,6 @@ type TypeInfo interface {
 	Version() byte
 	Custom() string
 
-	// New creates a pointer to an empty version of whatever type
-	// is referenced by the TypeInfo receiver.
-	//
-	// If there is no corresponding Go type for the CQL type, New panics.
-	//
-	// Deprecated: Use NewWithError instead.
-	New() interface{}
-
 	// NewWithError creates a pointer to an empty version of whatever type
 	// is referenced by the TypeInfo receiver.
 	//
@@ -2486,14 +2478,6 @@ func (t NativeType) NewWithError() (interface{}, error) {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
-}
-
-func (t NativeType) New() interface{} {
-	val, err := t.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
 }
 
 func (s NativeType) Type() Type {
@@ -2529,14 +2513,6 @@ func (t CollectionType) NewWithError() (interface{}, error) {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
-}
-
-func (t CollectionType) New() interface{} {
-	val, err := t.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
 }
 
 func (c CollectionType) String() string {
@@ -2576,14 +2552,6 @@ func (t TupleTypeInfo) NewWithError() (interface{}, error) {
 	return reflect.New(typ).Interface(), nil
 }
 
-func (t TupleTypeInfo) New() interface{} {
-	val, err := t.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
-}
-
 type UDTField struct {
 	Name string
 	Type TypeInfo
@@ -2602,14 +2570,6 @@ func (u UDTTypeInfo) NewWithError() (interface{}, error) {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
-}
-
-func (u UDTTypeInfo) New() interface{} {
-	val, err := u.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
 }
 
 func (u UDTTypeInfo) String() string {


### PR DESCRIPTION
This PR removes some features that are marked as "Deprecated".
Such as: 
* global var Timeout limit;
    `TimeoutLimit` was removed because it was always equal to 0 and the only condition where it was used was always false by 
    default. 

* `MustParseConsistency()` function;
    It was removed due to its deprecation.

* `New()` method for `typeInfo{}` interface;
    It was removed due to its deprecation. Instead of the removed method, the `typeInfo{}` interface has the 
    `NewWithError()` that returns an error instead of panicking.

* View field for the KeyspaceMetadata structure;
    Removed because of new and more informative `MaterializedViews` field.
    
