### PR TITLE
CASSGO-39 Add exec attempt interceptor (round 3)

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -258,9 +258,9 @@ type ClusterConfig struct {
 	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
 	DisableSkipMetadata bool
 
-	// QueryAttemptInterceptor will set the provided query interceptor on all queries created from this session.
-	// Use it to intercept and modify queries by providing an implementation of QueryAttemptInterceptor.
-	QueryAttemptInterceptor QueryAttemptInterceptor
+	// ExecAttemptInterceptor will set the provided interceptor on all queries/batches created from this session.
+	// Use it to intercept queries by providing an implementation of ExecAttemptInterceptor.
+	ExecAttemptInterceptor ExecAttemptInterceptor
 
 	// QueryObserver will set the provided query observer on all queries created from this session.
 	// Use it to collect metrics / stats from queries by providing an implementation of QueryObserver.

--- a/cluster.go
+++ b/cluster.go
@@ -258,6 +258,10 @@ type ClusterConfig struct {
 	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
 	DisableSkipMetadata bool
 
+	// QueryAttemptInterceptor will set the provided query interceptor on all queries created from this session.
+	// Use it to intercept and modify queries by providing an implementation of QueryAttemptInterceptor.
+	QueryAttemptInterceptor QueryAttemptInterceptor
+
 	// QueryObserver will set the provided query observer on all queries created from this session.
 	// Use it to collect metrics / stats from queries by providing an implementation of QueryObserver.
 	QueryObserver QueryObserver

--- a/control.go
+++ b/control.go
@@ -591,7 +591,7 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 				NewLogFieldString("statement", statement), NewLogFieldError("err", iter.err))
 		}
 
-		qry.metrics.attempt(0)
+		qry.metrics.recordAttempt(0, 0, nil)
 		qry.hostMetricsManager.attempt(0, c.getConn().host)
 		if iter.err == nil || !c.retry.Attempt(qry) {
 			break

--- a/control.go
+++ b/control.go
@@ -590,7 +590,7 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 				NewLogFieldString("statement", statement), NewLogFieldError("err", iter.err))
 		}
 
-		qry.metrics.attempt(0)
+		qry.metrics.recordAttempt(0, 0, nil)
 		qry.hostMetricsManager.attempt(0, c.getConn().host)
 		if iter.err == nil || !c.retry.Attempt(qry) {
 			break

--- a/doc.go
+++ b/doc.go
@@ -813,6 +813,18 @@
 //
 // See Example_userDefinedTypesMap, Example_userDefinedTypesStruct, ExampleUDTMarshaler, ExampleUDTUnmarshaler.
 //
+// # Interceptors
+//
+// A QueryAttemptInterceptor wraps query execution and can be used to inject logic that should apply to all query
+// and batch execution attempts. For example, interceptors can be used for rate limiting, logging, attaching
+// distributed tracing metadata to the context, modifying queries, and inspecting query results.
+//
+// A QueryAttemptInterceptor will be invoked once prior to each query execution attempt, including retry attempts
+// and speculative execution attempts. Interceptors are responsible for calling the provided handler and returning
+// a non-nil Iter.
+//
+// See Example_interceptor for full example.
+//
 // # Metrics and tracing
 //
 // It is possible to provide observer implementations that could be used to gather metrics:

--- a/doc.go
+++ b/doc.go
@@ -815,11 +815,12 @@
 //
 // # Interceptors
 //
-// A QueryAttemptInterceptor wraps query execution and can be used to inject logic that should apply to all query
+// A ExecAttemptInterceptor wraps query/batch execution and can be used to inject logic that should apply to all query
 // and batch execution attempts. For example, interceptors can be used for rate limiting, logging, attaching
-// distributed tracing metadata to the context, modifying queries, and inspecting query results.
+// distributed tracing metadata to the context, and inspecting query/batch results. However, the query/batch itself
+// cannot be modified.
 //
-// A QueryAttemptInterceptor will be invoked once prior to each query execution attempt, including retry attempts
+// A ExecAttemptInterceptor will be invoked once prior to each query execution attempt, including retry attempts
 // and speculative execution attempts. Interceptors are responsible for calling the provided handler and returning
 // a non-nil Iter or an error.
 //

--- a/doc.go
+++ b/doc.go
@@ -821,7 +821,7 @@
 //
 // A QueryAttemptInterceptor will be invoked once prior to each query execution attempt, including retry attempts
 // and speculative execution attempts. Interceptors are responsible for calling the provided handler and returning
-// a non-nil Iter.
+// a non-nil Iter or an error.
 //
 // See Example_interceptor for full example.
 //

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -55,7 +55,7 @@ func (q MyQueryAttemptInterceptor) Intercept(
 
 	// Optionally bypass the handler and return an error to prevent query execution.
 	// For example, to simulate query timeouts.
-	if q.injectFault && attempt.Number == 1 {
+	if q.injectFault && attempt.Attempts == 0 {
 		<-time.After(1 * time.Second)
 		return gocql.NewIterWithErr(gocql.RequestErrWriteTimeout{})
 	}

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40
+ * Copyright (c) 2016, The Gocql authors,
+ * provided under the BSD-3-Clause License.
+ * See the NOTICE file distributed with this work for additional information.
+ */
+
+package gocql_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	gocql "github.com/gocql/gocql"
+)
+
+type MyQueryAttemptInterceptor struct {
+	injectFault bool
+}
+
+func (q MyQueryAttemptInterceptor) Intercept(
+	ctx context.Context,
+	query gocql.ExecutableQuery,
+	conn *gocql.Conn,
+	handler gocql.QueryAttemptHandler,
+) *gocql.Iter {
+	switch q := query.(type) {
+	case *gocql.Query:
+		// Inspect or modify query
+		query = q
+	case *gocql.Batch:
+		// Inspect or modify batch
+		query = q
+	}
+
+	// Inspect or modify context
+	ctx = context.WithValue(ctx, "trace-id", "123")
+
+	// Optionally bypass the handler and return an error to prevent query execution.
+	// For example, to simulate query timeouts.
+	if q.injectFault && query.Attempts() == 0 {
+		<-time.After(1 * time.Second)
+		return gocql.NewIterWithErr(gocql.RequestErrWriteTimeout{})
+	}
+
+	// The interceptor *must* invoke the handler to execute the query.
+	return handler(ctx, query, conn)
+}
+
+// Example_interceptor demonstrates how to implement a QueryAttemptInterceptor.
+func Example_interceptor() {
+	cluster := gocql.NewCluster("localhost:9042")
+	cluster.QueryAttemptInterceptor = MyQueryAttemptInterceptor{injectFault: true}
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Close()
+
+	ctx := context.Background()
+
+	var stringValue string
+	err = session.Query("select now() from system.local").
+		WithContext(ctx).
+		RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 2}).
+		Scan(&stringValue)
+	if err != nil {
+		log.Fatalf("query failed %T", err)
+	}
+	fmt.Println(stringValue)
+	// Output: MOOOO!
+}

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -40,7 +40,7 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	ctx context.Context,
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
-) *gocql.Iter {
+) (*gocql.Iter, error) {
 	switch q := attempt.Query.(type) {
 	case *gocql.Query:
 		// Inspect or modify query
@@ -57,11 +57,11 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	// For example, to simulate query timeouts.
 	if q.injectFault && attempt.Attempts == 0 {
 		<-time.After(1 * time.Second)
-		return gocql.NewIterWithErr(gocql.RequestErrWriteTimeout{})
+		return nil, gocql.RequestErrWriteTimeout{}
 	}
 
 	// The interceptor *must* invoke the handler to execute the query.
-	return handler(ctx, attempt)
+	return handler(ctx, attempt), nil
 }
 
 // Example_interceptor demonstrates how to implement a QueryAttemptInterceptor.

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -29,7 +29,7 @@ import (
 	"log"
 	"time"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 type MyQueryAttemptInterceptor struct {
@@ -41,13 +41,14 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
 ) (*gocql.Iter, error) {
-	switch q := attempt.Query.(type) {
+	switch q := attempt.Statement.Statement().(type) {
 	case *gocql.Query:
-		// Inspect or modify query
-		attempt.Query = q
+		// Inspect query
+		log.Println(q.Statement())
 	case *gocql.Batch:
-		// Inspect or modify batch
-		attempt.Query = q
+		// Inspect batch
+
+		log.Println(q.Entries[0].Stmt)
 	}
 
 	// Inspect or modify context
@@ -61,7 +62,7 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	}
 
 	// The interceptor *must* invoke the handler to execute the query.
-	return handler(ctx, attempt)
+	return handler(ctx)
 }
 
 // Example_interceptor demonstrates how to implement a QueryAttemptInterceptor.
@@ -79,9 +80,8 @@ func Example_interceptor() {
 
 	var stringValue string
 	err = session.Query("select now() from system.local").
-		WithContext(ctx).
 		RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 2}).
-		Scan(&stringValue)
+		ScanContext(ctx, &stringValue)
 	if err != nil {
 		log.Fatalf("query failed %T", err)
 	}
@@ -96,16 +96,16 @@ func (c QueryAttemptInterceptorChain) Intercept(
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
 ) (*gocql.Iter, error) {
-	return c.interceptors[0].Intercept(ctx, attempt, c.getNextHandler(0, handler))
+	return c.interceptors[0].Intercept(ctx, attempt, c.getNextHandler(0, attempt, handler))
 }
 
-func (c QueryAttemptInterceptorChain) getNextHandler(curr int, final gocql.QueryAttemptHandler) gocql.QueryAttemptHandler {
+func (c QueryAttemptInterceptorChain) getNextHandler(curr int, attempt gocql.QueryAttempt, final gocql.QueryAttemptHandler) gocql.QueryAttemptHandler {
 	if curr == len(c.interceptors)-1 {
 		return final
 	}
 
-	return func(ctx context.Context, attempt gocql.QueryAttempt) (*gocql.Iter, error) {
-		return c.interceptors[curr+1].Intercept(ctx, attempt, c.getNextHandler(curr+1, final))
+	return func(ctx context.Context) (*gocql.Iter, error) {
+		return c.interceptors[curr+1].Intercept(ctx, attempt, c.getNextHandler(curr+1, attempt, final))
 	}
 }
 
@@ -130,9 +130,8 @@ func Example_interceptor_chain() {
 
 	var stringValue string
 	err = session.Query("select now() from system.local").
-		WithContext(ctx).
 		RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 2}).
-		Scan(&stringValue)
+		ScanContext(ctx, &stringValue)
 	if err != nil {
 		log.Fatalf("query failed %T", err)
 	}

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -32,11 +32,11 @@ import (
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
-type MyQueryAttemptInterceptor struct {
+type MyExecAttemptInterceptor struct {
 	injectFault bool
 }
 
-func (q MyQueryAttemptInterceptor) Intercept(
+func (q MyExecAttemptInterceptor) Intercept(
 	ctx context.Context,
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
@@ -65,10 +65,10 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	return handler(ctx)
 }
 
-// Example_interceptor demonstrates how to implement a QueryAttemptInterceptor.
+// Example_interceptor demonstrates how to implement a ExecAttemptInterceptor.
 func Example_interceptor() {
 	cluster := gocql.NewCluster("localhost:9042")
-	cluster.QueryAttemptInterceptor = MyQueryAttemptInterceptor{injectFault: true}
+	cluster.ExecAttemptInterceptor = MyExecAttemptInterceptor{injectFault: true}
 
 	session, err := cluster.CreateSession()
 	if err != nil {
@@ -87,11 +87,11 @@ func Example_interceptor() {
 	}
 }
 
-type QueryAttemptInterceptorChain struct {
-	interceptors []gocql.QueryAttemptInterceptor
+type ExecAttemptInterceptorChain struct {
+	interceptors []gocql.ExecAttemptInterceptor
 }
 
-func (c QueryAttemptInterceptorChain) Intercept(
+func (c ExecAttemptInterceptorChain) Intercept(
 	ctx context.Context,
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
@@ -99,7 +99,7 @@ func (c QueryAttemptInterceptorChain) Intercept(
 	return c.interceptors[0].Intercept(ctx, attempt, c.getNextHandler(0, attempt, handler))
 }
 
-func (c QueryAttemptInterceptorChain) getNextHandler(curr int, attempt gocql.QueryAttempt, final gocql.QueryAttemptHandler) gocql.QueryAttemptHandler {
+func (c ExecAttemptInterceptorChain) getNextHandler(curr int, attempt gocql.QueryAttempt, final gocql.QueryAttemptHandler) gocql.QueryAttemptHandler {
 	if curr == len(c.interceptors)-1 {
 		return final
 	}
@@ -109,14 +109,14 @@ func (c QueryAttemptInterceptorChain) getNextHandler(curr int, attempt gocql.Que
 	}
 }
 
-// Example_interceptor_chain demonstrates how to chain QueryAttemptInterceptors.
+// Example_interceptor_chain demonstrates how to chain ExecAttemptInterceptors.
 func Example_interceptor_chain() {
 	cluster := gocql.NewCluster("localhost:9042")
-	cluster.QueryAttemptInterceptor = QueryAttemptInterceptorChain{
-		[]gocql.QueryAttemptInterceptor{
-			MyQueryAttemptInterceptor{},
-			MyQueryAttemptInterceptor{},
-			MyQueryAttemptInterceptor{},
+	cluster.ExecAttemptInterceptor = ExecAttemptInterceptorChain{
+		[]gocql.ExecAttemptInterceptor{
+			MyExecAttemptInterceptor{},
+			MyExecAttemptInterceptor{},
+			MyExecAttemptInterceptor{},
 		},
 	}
 

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -41,14 +41,13 @@ func (q MyExecAttemptInterceptor) Intercept(
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
 ) (*gocql.Iter, error) {
-	switch q := attempt.Statement.Statement().(type) {
-	case *gocql.Query:
+	switch attempt.Type {
+	case gocql.OpQuery:
 		// Inspect query
-		log.Println(q.Statement())
-	case *gocql.Batch:
+		log.Println(attempt.Query.Statement())
+	case gocql.OpBatch:
 		// Inspect batch
-
-		log.Println(q.Entries[0].Stmt)
+		log.Println(attempt.Batch.Entries()[0].Stmt)
 	}
 
 	// Inspect or modify context

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -87,32 +87,10 @@ func Example_interceptor() {
 	}
 }
 
-type ExecAttemptInterceptorChain struct {
-	interceptors []gocql.ExecAttemptInterceptor
-}
-
-func (c ExecAttemptInterceptorChain) Intercept(
-	ctx context.Context,
-	attempt gocql.QueryAttempt,
-	handler gocql.QueryAttemptHandler,
-) (*gocql.Iter, error) {
-	return c.interceptors[0].Intercept(ctx, attempt, c.getNextHandler(0, attempt, handler))
-}
-
-func (c ExecAttemptInterceptorChain) getNextHandler(curr int, attempt gocql.QueryAttempt, final gocql.QueryAttemptHandler) gocql.QueryAttemptHandler {
-	if curr == len(c.interceptors)-1 {
-		return final
-	}
-
-	return func(ctx context.Context) (*gocql.Iter, error) {
-		return c.interceptors[curr+1].Intercept(ctx, attempt, c.getNextHandler(curr+1, attempt, final))
-	}
-}
-
 // Example_interceptor_chain demonstrates how to chain ExecAttemptInterceptors.
 func Example_interceptor_chain() {
 	cluster := gocql.NewCluster("localhost:9042")
-	cluster.ExecAttemptInterceptor = ExecAttemptInterceptorChain{
+	cluster.ExecAttemptInterceptor = gocql.ExecAttemptInterceptorChain{
 		[]gocql.ExecAttemptInterceptor{
 			MyExecAttemptInterceptor{},
 			MyExecAttemptInterceptor{},

--- a/query_executor.go
+++ b/query_executor.go
@@ -85,11 +85,13 @@ type QueryAttempt struct {
 	LocalAddr net.Addr
 	// The remote address of the connection used to execute the query.
 	RemoteAddr net.Addr
-	// The number of previous query attempts. 0 for the initial attempt, 1 for the first retry, etc.
+	// The number of this query attempt. 0 for the initial attempt, 1 for the first retry, etc. Note that there may be multiple serial Attempts to different hosts within a single execution, whether main execution or speculative.
 	Attempts int
+	// The index of the speculative execution attempt this attempt is associated with, starting with index 1. -1 indicates this is the "main" execution.
+	SpeculativeExecutionCount int
 }
 
-// QueryAttemptHandler is a function that attempts query execution. This typically pickles internalRequest.execute() to hide private interfaces and types.
+// QueryAttemptHandler is a function that attempts query execution. The interceptor must call this once if it does not return an error.
 type QueryAttemptHandler = func(context.Context) (*Iter, error)
 
 // ExecAttemptInterceptor is the interface implemented by interceptors / middleware.
@@ -107,7 +109,30 @@ type ExecAttemptInterceptor interface {
 	Intercept(ctx context.Context, attempt QueryAttempt, handler QueryAttemptHandler) (*Iter, error)
 }
 
-func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, conn *Conn) *Iter {
+// Use an ExecAttemptInterceptorChain to apply multiple Interceptors at Intercept time.
+type ExecAttemptInterceptorChain struct {
+	Interceptors []ExecAttemptInterceptor
+}
+
+func (c ExecAttemptInterceptorChain) Intercept(
+	ctx context.Context,
+	attempt QueryAttempt,
+	handler QueryAttemptHandler,
+) (*Iter, error) {
+	return c.Interceptors[0].Intercept(ctx, attempt, c.getNextHandler(0, attempt, handler))
+}
+
+func (c ExecAttemptInterceptorChain) getNextHandler(curr int, attempt QueryAttempt, final QueryAttemptHandler) QueryAttemptHandler {
+	if curr == len(c.Interceptors)-1 {
+		return final
+	}
+
+	return func(ctx context.Context) (*Iter, error) {
+		return c.Interceptors[curr+1].Intercept(ctx, attempt, c.getNextHandler(curr+1, attempt, final))
+	}
+}
+
+func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, conn *Conn, speculativeExecutionCount int) *Iter {
 	start := time.Now()
 
 	var iter *Iter
@@ -122,6 +147,7 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 			LocalAddr:  conn.r.LocalAddr(),
 			RemoteAddr: conn.r.RemoteAddr(),
 			Attempts:   attempt,
+			SpeculativeExecutionCount: speculativeExecutionCount,
 		}
 		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context) (*Iter, error) {
 			ctx = _ctx
@@ -149,7 +175,7 @@ func (q *queryExecutor) speculate(ctx context.Context, qry internalRequest, sp S
 	for i := 0; i < sp.Attempts(); i++ {
 		select {
 		case <-ticker.C:
-			go q.run(ctx, qry, hostIter, results)
+			go q.run(ctx, qry, hostIter, i+1, results)
 		case <-ctx.Done():
 			return newErrIter(ctx.Err(), qry.getQueryMetrics(), qry.Keyspace(), qry.getRoutingInfo(), qry.getKeyspaceFunc())
 		case iter := <-results:
@@ -189,7 +215,7 @@ func (q *queryExecutor) executeQuery(qry internalRequest) (*Iter, error) {
 	// it is, we force the policy to NonSpeculative
 	sp := qry.speculativeExecutionPolicy()
 	if qry.GetHostID() != "" || !qry.IsIdempotent() || sp.Attempts() == 0 {
-		return q.do(qry.Context(), qry, hostIter), nil
+		return q.do(qry.Context(), qry, hostIter, -1), nil
 	}
 
 	// When speculative execution is enabled, we could be accessing the host iterator from multiple goroutines below.
@@ -208,7 +234,7 @@ func (q *queryExecutor) executeQuery(qry internalRequest) (*Iter, error) {
 	results := make(chan *Iter, 1)
 
 	// Launch the main execution
-	go q.run(ctx, qry, hostIter, results)
+	go q.run(ctx, qry, hostIter, -1, results)
 
 	// The speculative executions are launched _in addition_ to the main
 	// execution, on a timer. So Speculation{2} would make 3 executions running
@@ -225,7 +251,7 @@ func (q *queryExecutor) executeQuery(qry internalRequest) (*Iter, error) {
 	}
 }
 
-func (q *queryExecutor) do(ctx context.Context, qry internalRequest, hostIter NextHost) *Iter {
+func (q *queryExecutor) do(ctx context.Context, qry internalRequest, hostIter NextHost, speculativeExecutionCount int) *Iter {
 	selectedHost := hostIter()
 	rt := qry.retryPolicy()
 
@@ -250,7 +276,7 @@ func (q *queryExecutor) do(ctx context.Context, qry internalRequest, hostIter Ne
 			continue
 		}
 
-		iter = q.attemptQuery(ctx, qry, conn)
+		iter = q.attemptQuery(ctx, qry, conn, speculativeExecutionCount)
 		iter.host = selectedHost.Info()
 		// Update host
 		switch iter.err {
@@ -306,9 +332,9 @@ func (q *queryExecutor) do(ctx context.Context, qry internalRequest, hostIter Ne
 	return newErrIter(ErrNoConnections, qry.getQueryMetrics(), qry.Keyspace(), qry.getRoutingInfo(), qry.getKeyspaceFunc())
 }
 
-func (q *queryExecutor) run(ctx context.Context, qry internalRequest, hostIter NextHost, results chan<- *Iter) {
+func (q *queryExecutor) run(ctx context.Context, qry internalRequest, hostIter NextHost, speculativeExecutionCount int, results chan<- *Iter) {
 	select {
-	case results <- q.do(ctx, qry, hostIter):
+	case results <- q.do(ctx, qry, hostIter, speculativeExecutionCount):
 	case <-ctx.Done():
 	}
 }

--- a/query_executor.go
+++ b/query_executor.go
@@ -74,8 +74,19 @@ type queryExecutor struct {
 	interceptor QueryAttemptInterceptor
 }
 
+type QueryAttempt struct {
+	// The query to execute, either a *gocql.Query or *gocql.Batch.
+	Query ExecutableStatement
+	// The connection used to execute the query.
+	Conn *Conn
+	// The host that will receive the query.
+	Host *HostInfo
+	// The number of previous query attempts. 0 for the initial attempt, 1 for the first retry, etc.
+	Attempts int
+}
+
 // QueryAttemptHandler is a function that attempts query execution.
-type QueryAttemptHandler = func(context.Context, ExecutableStatement, *Conn) *Iter
+type QueryAttemptHandler = func(context.Context, QueryAttempt) *Iter
 
 // QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
 //
@@ -87,7 +98,7 @@ type QueryAttemptInterceptor interface {
 	// The interceptor is responsible for calling the `handler` function and returning the handler result. Failure to
 	// call the handler will panic. If the interceptor wants to halt query execution and prevent retries, it should
 	// return an error.
-	Intercept(ctx context.Context, query ExecutableStatement, conn *Conn, handler QueryAttemptHandler) *Iter
+	Intercept(ctx context.Context, attempt QueryAttempt, handler QueryAttemptHandler) *Iter
 }
 
 func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, conn *Conn) *Iter {
@@ -97,9 +108,15 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 	if q.interceptor != nil {
 		// Propagate interceptor context modifications.
 		_ctx := ctx
-		iter = q.interceptor.Intercept(_ctx, qry, conn, func(_ctx context.Context, qry ExecutableQuery, c *Conn) *Iter {
+		attempt := QueryAttempt{
+			Query:    qry,
+			Conn:     conn,
+			Host:     conn.host,
+			Attempts: qry.Attempts(),
+		}
+		iter = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) *Iter {
 			ctx = _ctx
-			return qry.execute(ctx, conn)
+			return attempt.Query.execute(ctx, attempt.Conn)
 		})
 	} else {
 		iter = qry.execute(ctx, conn)

--- a/query_executor.go
+++ b/query_executor.go
@@ -73,7 +73,7 @@ type internalRequest interface {
 type queryExecutor struct {
 	pool        *policyConnPool
 	policy      HostSelectionPolicy
-	interceptor QueryAttemptInterceptor
+	interceptor ExecAttemptInterceptor
 }
 
 type QueryAttempt struct {
@@ -92,16 +92,18 @@ type QueryAttempt struct {
 // QueryAttemptHandler is a function that attempts query execution. This typically pickles internalRequest.execute() to hide private interfaces and types.
 type QueryAttemptHandler = func(context.Context) (*Iter, error)
 
-// QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
+// ExecAttemptInterceptor is the interface implemented by interceptors / middleware.
 //
-// Interceptors are well-suited to logic that is not specific to a single query or batch.
-type QueryAttemptInterceptor interface {
-	// Intercept is invoked once immediately before a query execution attempt, including retry attempts and
+// Interceptors are well-suited to logic that is not specific to a single query or batch, such as flow control.
+type ExecAttemptInterceptor interface {
+	// Intercept is invoked once immediately before a query or batch execution attempt, including retry attempts and
 	// speculative execution attempts.
-
+	//
 	// The interceptor is responsible for calling the `handler` function and returning the handler result. If the
 	// interceptor wants to bypass the handler and skip query execution, it should return an error. Failure to
 	// return either the handler result or an error will panic.
+	//
+	// Note that there is no affordance to mutate the query or batch at this stage -- the handler already encapsulates the original query/batch and cannot be modified.
 	Intercept(ctx context.Context, attempt QueryAttempt, handler QueryAttemptHandler) (*Iter, error)
 }
 

--- a/query_executor.go
+++ b/query_executor.go
@@ -95,16 +95,17 @@ type QueryAttemptInterceptor interface {
 	// Intercept is invoked once immediately before a query execution attempt, including retry attempts and
 	// speculative execution attempts.
 
-	// The interceptor is responsible for calling the `handler` function and returning the handler result. Failure to
-	// call the handler will panic. If the interceptor wants to halt query execution and prevent retries, it should
-	// return an error.
-	Intercept(ctx context.Context, attempt QueryAttempt, handler QueryAttemptHandler) *Iter
+	// The interceptor is responsible for calling the `handler` function and returning the handler result. If the
+	// interceptor wants to bypass the handler and skip query execution, it should return an error. Failure to
+	// return either the handler result or an error will panic.
+	Intercept(ctx context.Context, attempt QueryAttempt, handler QueryAttemptHandler) (*Iter, error)
 }
 
 func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, conn *Conn) *Iter {
 	start := time.Now()
 
 	var iter *Iter
+	var err error
 	if q.interceptor != nil {
 		// Propagate interceptor context modifications.
 		_ctx := ctx
@@ -114,10 +115,13 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 			Host:     conn.host,
 			Attempts: qry.Attempts(),
 		}
-		iter = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) *Iter {
+		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) *Iter {
 			ctx = _ctx
 			return attempt.Query.execute(ctx, attempt.Conn)
 		})
+		if err != nil {
+			iter = &Iter{err: err}
+		}
 	} else {
 		iter = qry.execute(ctx, conn)
 	}

--- a/query_executor.go
+++ b/query_executor.go
@@ -59,7 +59,8 @@ type Statement interface {
 
 type internalRequest interface {
 	execute(ctx context.Context, conn *Conn) *Iter
-	attempt(ctx context.Context, keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
+	getNextAttempt() int
+	recordAttempt(attemptNum int, keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
 	speculativeExecutionPolicy() SpeculativeExecutionPolicy
 	getQueryMetrics() *queryMetrics
@@ -76,10 +77,8 @@ type queryExecutor struct {
 }
 
 type QueryAttempt struct {
-	// The query to execute, either a *gocql.Query or *gocql.Batch.
-	Query ExecutableStatement
-	// The connection used to execute the query.
-	Conn *Conn
+	// The statement to execute, either a *gocql.Query or *gocql.Batch.
+	Statement ExecutableStatement
 	// The host that will receive the query.
 	Host *HostInfo
 	// The local address of the connection used to execute the query.
@@ -90,8 +89,8 @@ type QueryAttempt struct {
 	Attempts int
 }
 
-// QueryAttemptHandler is a function that attempts query execution.
-type QueryAttemptHandler = func(context.Context, QueryAttempt) (*Iter, error)
+// QueryAttemptHandler is a function that attempts query execution. This typically pickles internalRequest.execute() to hide private interfaces and types.
+type QueryAttemptHandler = func(context.Context) (*Iter, error)
 
 // QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
 //
@@ -111,19 +110,20 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 
 	var iter *Iter
 	var err error
+	attempt := qry.getNextAttempt()
 	if q.interceptor != nil {
 		// Propagate interceptor context modifications.
 		_ctx := ctx
 		attempt := QueryAttempt{
-			Query:      qry,
+			Statement:  ExecutableStatement(qry),
 			Host:       conn.host,
-			LocalAddr:  conn.conn.LocalAddr(),
-			RemoteAddr: conn.conn.RemoteAddr(),
-			Attempts:   qry.Attempts(),
+			LocalAddr:  conn.r.LocalAddr(),
+			RemoteAddr: conn.r.RemoteAddr(),
+			Attempts:   attempt,
 		}
-		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) (*Iter, error) {
+		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context) (*Iter, error) {
 			ctx = _ctx
-			iter := attempt.Query.execute(ctx, conn)
+			iter := qry.execute(ctx, conn)
 			return iter, iter.err
 		})
 		if err != nil {
@@ -134,7 +134,7 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 	}
 
 	end := time.Now()
-	qry.attempt(ctx, q.pool.keyspace, end, start, iter, conn.host)
+	qry.recordAttempt(attempt, q.pool.keyspace, end, start, iter, conn.host)
 
 	return iter
 }
@@ -427,14 +427,18 @@ func newInternalQuery(q *Query, ctx context.Context) *internalQuery {
 	}
 }
 
-// Attempts returns the number of times the query was executed.
+// getNextAttempt returns the index of the next attempt. Calling this increments the attempt counter by one.
+func (q *internalQuery) getNextAttempt() int {
+	return q.metrics.getNextAttempt()
+}
+
 func (q *internalQuery) Attempts() int {
 	return q.metrics.attempts()
 }
 
-func (q *internalQuery) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
+func (q *internalQuery) recordAttempt(attemptNum int, keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
 	latency := end.Sub(start)
-	attempt := q.metrics.attempt(latency)
+	q.metrics.recordAttempt(attemptNum, latency, q.session)
 
 	if q.qryOpts.observer != nil {
 		metricsForHost := q.hostMetricsManager.attempt(latency, host)
@@ -453,7 +457,7 @@ func (q *internalQuery) attempt(keyspace string, end, start time.Time, iter *Ite
 			Host:       host,
 			Metrics:    metricsForHost,
 			Err:        iter.err,
-			Attempt:    attempt,
+			Attempt:    attemptNum,
 			Query:      q.originalQuery,
 		})
 	}
@@ -657,14 +661,18 @@ func newInternalBatch(batch *Batch, ctx context.Context) *internalBatch {
 	}
 }
 
+func (b *internalBatch) getNextAttempt() int {
+	return b.metrics.getNextAttempt()
+}
+
 // Attempts returns the number of attempts made to execute the batch.
 func (b *internalBatch) Attempts() int {
 	return b.metrics.attempts()
 }
 
-func (b *internalBatch) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
+func (b *internalBatch) recordAttempt(attemptNum int, keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
 	latency := end.Sub(start)
-	attempt := b.metrics.attempt(latency)
+	b.metrics.recordAttempt(attemptNum, latency, b.session)
 
 	if b.batchOpts.observer == nil {
 		return
@@ -700,7 +708,7 @@ func (b *internalBatch) attempt(keyspace string, end, start time.Time, iter *Ite
 		Host:    host,
 		Metrics: metricsForHost,
 		Err:     iter.err,
-		Attempt: attempt,
+		Attempt: attemptNum,
 		Batch:   b.originalBatch,
 	})
 }

--- a/query_executor.go
+++ b/query_executor.go
@@ -58,7 +58,7 @@ type Statement interface {
 
 type internalRequest interface {
 	execute(ctx context.Context, conn *Conn) *Iter
-	attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
+	attempt(ctx context.Context, keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
 	speculativeExecutionPolicy() SpeculativeExecutionPolicy
 	getQueryMetrics() *queryMetrics
@@ -69,16 +69,45 @@ type internalRequest interface {
 }
 
 type queryExecutor struct {
-	pool   *policyConnPool
-	policy HostSelectionPolicy
+	pool        *policyConnPool
+	policy      HostSelectionPolicy
+	interceptor QueryAttemptInterceptor
+}
+
+// QueryAttemptHandler is a function that attempts query execution.
+type QueryAttemptHandler = func(context.Context, ExecutableStatement, *Conn) *Iter
+
+// QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
+//
+// Interceptors are well-suited to logic that is not specific to a single query or batch.
+type QueryAttemptInterceptor interface {
+	// Intercept is invoked once immediately before a query execution attempt, including retry attempts and
+	// speculative execution attempts.
+
+	// The interceptor is responsible for calling the `handler` function and returning the handler result. Failure to
+	// call the handler will panic. If the interceptor wants to halt query execution and prevent retries, it should
+	// return an error.
+	Intercept(ctx context.Context, query ExecutableStatement, conn *Conn, handler QueryAttemptHandler) *Iter
 }
 
 func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, conn *Conn) *Iter {
 	start := time.Now()
-	iter := qry.execute(ctx, conn)
-	end := time.Now()
 
-	qry.attempt(q.pool.keyspace, end, start, iter, conn.host)
+	var iter *Iter
+	if q.interceptor != nil {
+		// Propagate interceptor context modifications.
+		_ctx := ctx
+		iter = q.interceptor.Intercept(_ctx, qry, conn, func(_ctx context.Context, qry ExecutableQuery, c *Conn) *Iter {
+			ctx = _ctx
+			return qry.execute(ctx, conn)
+		})
+	} else {
+		iter = qry.execute(ctx, conn)
+		return iter
+	}
+
+	end := time.Now()
+	qry.attempt(ctx, q.pool.keyspace, end, start, iter, conn.host)
 
 	return iter
 }

--- a/query_executor.go
+++ b/query_executor.go
@@ -76,9 +76,58 @@ type queryExecutor struct {
 	interceptor ExecAttemptInterceptor
 }
 
+type OpType int
+
+const (
+	OpQuery OpType = iota
+	OpBatch
+)
+
+type ImmutableQuery interface {
+	Statement() string
+	Values() []interface{}
+}
+
+type immutableQuery struct {
+	query *Query
+}
+
+func (q *immutableQuery) Statement() string {
+	return q.query.stmt
+}
+
+func (q *immutableQuery) Values() []interface{} {
+	return q.query.values
+}
+
+type ImmutableBatch interface {
+	Type() BatchType
+	Entries() []BatchEntry
+	Cons() Consistency
+}
+
+type immutableBatch struct {
+	batch *Batch
+}
+
+func (b *immutableBatch) Type() BatchType {
+	return b.batch.Type
+}
+
+func (b *immutableBatch) Entries() []BatchEntry {
+	return b.batch.Entries
+}
+
+func (b *immutableBatch) Cons() Consistency {
+	return b.batch.Cons
+}
+
 type QueryAttempt struct {
-	// The statement to execute, either a *gocql.Query or *gocql.Batch.
-	Statement ExecutableStatement
+	// The op type, whether query or batch.
+	Type OpType
+	// Only one of Query or Batch will be set, depending on the op type.
+	Query ImmutableQuery
+	Batch ImmutableBatch
 	// The host that will receive the query.
 	Host *HostInfo
 	// The local address of the connection used to execute the query.
@@ -132,37 +181,41 @@ func (c ExecAttemptInterceptorChain) getNextHandler(curr int, attempt QueryAttem
 	}
 }
 
-func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, conn *Conn, speculativeExecutionCount int) *Iter {
+func (q *queryExecutor) attemptQuery(ctx context.Context, iRequest internalRequest, conn *Conn, speculativeExecutionCount int) *Iter {
 	start := time.Now()
 
 	var iter *Iter
 	var err error
-	attempt := qry.getNextAttempt()
+	attempt := iRequest.getNextAttempt()
 	if q.interceptor != nil {
-		// Propagate interceptor context modifications.
-		_ctx := ctx
-		attempt := QueryAttempt{
-			Statement:  ExecutableStatement(qry),
-			Host:       conn.host,
-			LocalAddr:  conn.r.LocalAddr(),
-			RemoteAddr: conn.r.RemoteAddr(),
-			Attempts:   attempt,
+		iq := QueryAttempt{
+			Host:                      conn.host,
+			LocalAddr:                 conn.r.LocalAddr(),
+			RemoteAddr:                conn.r.RemoteAddr(),
+			Attempts:                  attempt,
 			SpeculativeExecutionCount: speculativeExecutionCount,
 		}
-		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context) (*Iter, error) {
-			ctx = _ctx
-			iter := qry.execute(ctx, conn)
-			return iter, iter.err
+		if iQuery, ok := iRequest.(*internalQuery); ok {
+			iq.Type = OpQuery
+			iq.Query = &immutableQuery{query: iQuery.originalQuery}
+		}
+		if iBatch, ok := iRequest.(*internalBatch); ok {
+			iq.Type = OpBatch
+			iq.Batch = &immutableBatch{batch: iBatch.originalBatch}
+		}
+		iter, err = q.interceptor.Intercept(ctx, iq, func(cxCtx context.Context) (*Iter, error) {
+			it := iRequest.execute(cxCtx, conn)
+			return it, it.err
 		})
 		if err != nil {
 			iter = &Iter{err: err}
 		}
 	} else {
-		iter = qry.execute(ctx, conn)
+		iter = iRequest.execute(ctx, conn)
 	}
 
 	end := time.Now()
-	qry.recordAttempt(attempt, q.pool.keyspace, end, start, iter, conn.host)
+	iRequest.recordAttempt(attempt, q.pool.keyspace, end, start, iter, conn.host)
 
 	return iter
 }

--- a/query_executor.go
+++ b/query_executor.go
@@ -86,7 +86,7 @@ type QueryAttempt struct {
 }
 
 // QueryAttemptHandler is a function that attempts query execution.
-type QueryAttemptHandler = func(context.Context, QueryAttempt) *Iter
+type QueryAttemptHandler = func(context.Context, QueryAttempt) (*Iter, error)
 
 // QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
 //
@@ -115,9 +115,10 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 			Host:     conn.host,
 			Attempts: qry.Attempts(),
 		}
-		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) *Iter {
+		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) (*Iter, error) {
 			ctx = _ctx
-			return attempt.Query.execute(ctx, attempt.Conn)
+			iter := attempt.Query.execute(ctx, attempt.Conn)
+			return iter, iter.err
 		})
 		if err != nil {
 			iter = &Iter{err: err}

--- a/query_executor.go
+++ b/query_executor.go
@@ -26,6 +26,7 @@ package gocql
 
 import (
 	"context"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -81,6 +82,10 @@ type QueryAttempt struct {
 	Conn *Conn
 	// The host that will receive the query.
 	Host *HostInfo
+	// The local address of the connection used to execute the query.
+	LocalAddr net.Addr
+	// The remote address of the connection used to execute the query.
+	RemoteAddr net.Addr
 	// The number of previous query attempts. 0 for the initial attempt, 1 for the first retry, etc.
 	Attempts int
 }
@@ -110,14 +115,15 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 		// Propagate interceptor context modifications.
 		_ctx := ctx
 		attempt := QueryAttempt{
-			Query:    qry,
-			Conn:     conn,
-			Host:     conn.host,
-			Attempts: qry.Attempts(),
+			Query:      qry,
+			Host:       conn.host,
+			LocalAddr:  conn.conn.LocalAddr(),
+			RemoteAddr: conn.conn.RemoteAddr(),
+			Attempts:   qry.Attempts(),
 		}
 		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) (*Iter, error) {
 			ctx = _ctx
-			iter := attempt.Query.execute(ctx, attempt.Conn)
+			iter := attempt.Query.execute(ctx, conn)
 			return iter, iter.err
 		})
 		if err != nil {

--- a/query_executor.go
+++ b/query_executor.go
@@ -103,7 +103,6 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 		})
 	} else {
 		iter = qry.execute(ctx, conn)
-		return iter
 	}
 
 	end := time.Now()

--- a/query_executor.go
+++ b/query_executor.go
@@ -59,7 +59,8 @@ type Statement interface {
 
 type internalRequest interface {
 	execute(ctx context.Context, conn *Conn) *Iter
-	attempt(ctx context.Context, keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
+	getNextAttempt() int
+	recordAttempt(attemptNum int, keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
 	speculativeExecutionPolicy() SpeculativeExecutionPolicy
 	getQueryMetrics() *queryMetrics
@@ -76,10 +77,8 @@ type queryExecutor struct {
 }
 
 type QueryAttempt struct {
-	// The query to execute, either a *gocql.Query or *gocql.Batch.
-	Query ExecutableStatement
-	// The connection used to execute the query.
-	Conn *Conn
+	// The statement to execute, either a *gocql.Query or *gocql.Batch.
+	Statement ExecutableStatement
 	// The host that will receive the query.
 	Host *HostInfo
 	// The local address of the connection used to execute the query.
@@ -90,8 +89,8 @@ type QueryAttempt struct {
 	Attempts int
 }
 
-// QueryAttemptHandler is a function that attempts query execution.
-type QueryAttemptHandler = func(context.Context, QueryAttempt) (*Iter, error)
+// QueryAttemptHandler is a function that attempts query execution. This typically pickles internalRequest.execute() to hide private interfaces and types.
+type QueryAttemptHandler = func(context.Context) (*Iter, error)
 
 // QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
 //
@@ -111,19 +110,20 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 
 	var iter *Iter
 	var err error
+	attempt := qry.getNextAttempt()
 	if q.interceptor != nil {
 		// Propagate interceptor context modifications.
 		_ctx := ctx
 		attempt := QueryAttempt{
-			Query:      qry,
+			Statement:  ExecutableStatement(qry),
 			Host:       conn.host,
-			LocalAddr:  conn.conn.LocalAddr(),
-			RemoteAddr: conn.conn.RemoteAddr(),
-			Attempts:   qry.Attempts(),
+			LocalAddr:  conn.r.LocalAddr(),
+			RemoteAddr: conn.r.RemoteAddr(),
+			Attempts:   attempt,
 		}
-		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) (*Iter, error) {
+		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context) (*Iter, error) {
 			ctx = _ctx
-			iter := attempt.Query.execute(ctx, conn)
+			iter := qry.execute(ctx, conn)
 			return iter, iter.err
 		})
 		if err != nil {
@@ -134,7 +134,7 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry internalRequest, c
 	}
 
 	end := time.Now()
-	qry.attempt(ctx, q.pool.keyspace, end, start, iter, conn.host)
+	qry.recordAttempt(attempt, q.pool.keyspace, end, start, iter, conn.host)
 
 	return iter
 }
@@ -427,14 +427,18 @@ func newInternalQuery(q *Query, ctx context.Context) *internalQuery {
 	}
 }
 
-// Attempts returns the number of times the query was executed.
+// getNextAttempt returns the index of the next attempt. Calling this increments the attempt counter by one.
+func (q *internalQuery) getNextAttempt() int {
+	return q.metrics.getNextAttempt()
+}
+
 func (q *internalQuery) Attempts() int {
 	return q.metrics.attempts()
 }
 
-func (q *internalQuery) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
+func (q *internalQuery) recordAttempt(attemptNum int, keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
 	latency := end.Sub(start)
-	attempt := q.metrics.attempt(latency)
+	q.metrics.recordAttempt(attemptNum, latency, q.session)
 
 	if q.qryOpts.observer != nil {
 		metricsForHost := q.hostMetricsManager.attempt(latency, host)
@@ -448,7 +452,7 @@ func (q *internalQuery) attempt(keyspace string, end, start time.Time, iter *Ite
 			Host:      host,
 			Metrics:   metricsForHost,
 			Err:       iter.err,
-			Attempt:   attempt,
+			Attempt:   attemptNum,
 			Query:     q.originalQuery,
 		})
 	}
@@ -638,14 +642,18 @@ func newInternalBatch(batch *Batch, ctx context.Context) *internalBatch {
 	}
 }
 
+func (b *internalBatch) getNextAttempt() int {
+	return b.metrics.getNextAttempt()
+}
+
 // Attempts returns the number of attempts made to execute the batch.
 func (b *internalBatch) Attempts() int {
 	return b.metrics.attempts()
 }
 
-func (b *internalBatch) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
+func (b *internalBatch) recordAttempt(attemptNum int, keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
 	latency := end.Sub(start)
-	attempt := b.metrics.attempt(latency)
+	b.metrics.recordAttempt(attemptNum, latency, b.session)
 
 	if b.batchOpts.observer == nil {
 		return
@@ -671,7 +679,7 @@ func (b *internalBatch) attempt(keyspace string, end, start time.Time, iter *Ite
 		Host:    host,
 		Metrics: metricsForHost,
 		Err:     iter.err,
-		Attempt: attempt,
+		Attempt: attemptNum,
 		Batch:   b.originalBatch,
 	})
 }

--- a/session.go
+++ b/session.go
@@ -232,7 +232,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	s.executor = &queryExecutor{
 		pool:        s.pool,
 		policy:      cfg.PoolConfig.HostSelectionPolicy,
-		interceptor: cfg.QueryAttemptInterceptor,
+		interceptor: cfg.ExecAttemptInterceptor,
 	}
 
 	s.policy.Init(s)

--- a/session.go
+++ b/session.go
@@ -232,6 +232,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	s.executor = &queryExecutor{
 		pool:   s.pool,
 		policy: cfg.PoolConfig.HostSelectionPolicy,
+		interceptor: cfg.QueryAttemptInterceptor,
 	}
 
 	s.policy.Init(s)

--- a/session.go
+++ b/session.go
@@ -230,8 +230,8 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 
 	// set the executor here in case the policy needs to execute queries in Init
 	s.executor = &queryExecutor{
-		pool:   s.pool,
-		policy: cfg.PoolConfig.HostSelectionPolicy,
+		pool:        s.pool,
+		policy:      cfg.PoolConfig.HostSelectionPolicy,
 		interceptor: cfg.QueryAttemptInterceptor,
 	}
 
@@ -969,26 +969,49 @@ type hostMetrics struct {
 	TotalLatency int64
 }
 
+// Query attempts could be started and finished out of order when using speculative execution. Therefore,
+// we issue attempt indexes at query start time (so that Interceptors can use them) then record those attempts
+// at completion time (so that metrics can correctly express average latency).
 type queryMetrics struct {
-	totalAttempts int64
-	totalLatency  int64
+	l                 sync.RWMutex
+	attemptsStarted   int
+	attemptsCompleted int
+	totalLatency      int64
 }
 
-func (qm *queryMetrics) attempt(addLatency time.Duration) int {
-	atomic.AddInt64(&qm.totalLatency, addLatency.Nanoseconds())
-	return int(atomic.AddInt64(&qm.totalAttempts, 1) - 1)
+func (qm *queryMetrics) getNextAttempt() int {
+	qm.l.Lock()
+	defer qm.l.Unlock()
+	attempt := qm.attemptsStarted
+	qm.attemptsStarted++
+	return attempt
 }
 
+func (qm *queryMetrics) recordAttempt(attempt int, addLatency time.Duration, s *Session) {
+	qm.l.Lock()
+	defer qm.l.Unlock()
+	qm.totalLatency += addLatency.Nanoseconds()
+	qm.attemptsCompleted++
+	if attempt > qm.attemptsCompleted && s != nil {
+		s.logger.Debug("attempt number is greater than total attempts completed, this should not happen", NewLogFieldInt("attempt", attempt), NewLogFieldInt("attemptsCompleted", qm.attemptsCompleted))
+	}
+}
+
+// Returns total number of attempts started.
 func (qm *queryMetrics) attempts() int {
-	return int(atomic.LoadInt64(&qm.totalAttempts))
+	qm.l.RLock()
+	defer qm.l.RUnlock()
+	return qm.attemptsStarted
 }
 
 func (qm *queryMetrics) latency() int64 {
-	attempts := atomic.LoadInt64(&qm.totalAttempts)
+	qm.l.RLock()
+	defer qm.l.RUnlock()
+	attempts := qm.attemptsCompleted
 	if attempts == 0 {
-		return atomic.LoadInt64(&qm.totalLatency)
+		return qm.totalLatency
 	}
-	return atomic.LoadInt64(&qm.totalLatency) / attempts
+	return qm.totalLatency / int64(attempts)
 }
 
 type hostMetricsManager interface {


### PR DESCRIPTION
This supersedes https://github.com/apache/cassandra-gocql-driver/pull/1820 rebasing on top of, and taking into account, changes in v2.

Notably, this removes the ability to mutate the Statement in the Interceptor -- it is now embedded in the `internalRequest`, making it inaccessible to a public API without invasive refactoring.

Additionally, I modified `queryMetrics` in a few ways:

* Made it threadsafe, so that latency and attempt count are updated under lock, preventing a potential race when reading latency
* Separated out "attempts started" from "attempts completed". Speculative execution means that several attempts could happen concurrently, and this guarantees that (a) each attempt/interception gets its own attempt count, and (b) the retry policy respects attempts started, to prevent over-retry when earlier retries haven't completed yet.

Fixes #1786.