### PR TITLE
CASSGO-123 Bump C* versions in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.25', '1.26' ]
-        cassandra_version: [ '4.1.6', '5.0.3' ]
+        cassandra_version: [ '4.1.11', '5.0.8' ]
         auth: [ "false" ]
         compressor: [ "no-compression", "snappy", "lz4" ]
         tags: [ "cassandra", "integration", "ccm" ]
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.25', '1.26' ]
-        cassandra_version: [ '4.0.13' ]
+        cassandra_version: [ '4.1.11', '5.0.8' ]
         compressor: [ "no-compression", "snappy", "lz4" ]
         tags: [ "integration" ]
         proto_version: [ "4", "5" ]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := bash
 MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 KEY_PATH = ${MAKEFILE_PATH}/testdata/pki
 
-CASSANDRA_VERSION ?= 4.1.6
+CASSANDRA_VERSION ?= 4.1.11
 TEST_CQL_PROTOCOL ?= 4
 TEST_COMPRESSOR ?= no-compression
 TEST_INTEGRATION_TAGS ?= integration


### PR DESCRIPTION
Bumped:
- 4.1.6 -> 4.1.11
- 5.0.3 -> 5.0.8

Removed C* 4.0.13 auth test matrix

Patch by Bohdan Siryk; reviwed by TBD for CASSGO-123