### PR TITLE
CASSGO-132 Prevent syntetic CREATED events on HostSelectionPolicy.KeyspaceChanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Query.Binding() method to override binding function for a query object.
 
 ### Fixed
+
 - Correct protocol negotiation with non-Cassandra servers (CASSGO-131)
 - LZ4 test fails on arm64 (CASSGO-128)
+- Prevent syntetic CREATED events on HostSelectionPolicy.KeyspaceChanged during session init (CASSGO-132)
 
 ## [2.1.2]
 

--- a/cluster.go
+++ b/cluster.go
@@ -405,9 +405,26 @@ func (cfg *ClusterConfig) filterHost(host *HostInfo) bool {
 	return !(cfg.HostFilter == nil || cfg.HostFilter.Accept(host))
 }
 
+func (cfg *ClusterConfig) validate() error {
+	logger := cfg.newLogger()
+
+	if cfg.Metadata.CacheMode == Disabled {
+		mrp, ok := cfg.PoolConfig.HostSelectionPolicy.(MetadataRequiredPolicy)
+		if !ok {
+			logger.Warning(metadataCacheDisabledWarningMsg)
+		} else if mrp.MetadataRequired() {
+			return ErrMetadataCacheRequired
+		}
+	}
+
+	return nil
+}
+
 // MetadataConfig configures driver's internal metadata caching and event listening.
 type MetadataConfig struct {
 	// CacheMode controls how the driver reads and caches schema metadata from Cassandra system tables.
+	//
+	// It is required to be enabled for [TokenAwareHostPolicy] and custom host selection policies.
 	//
 	// Also, it affects the behavior of schema change listeners.
 	//
@@ -465,4 +482,10 @@ var (
 	ErrNoConnectionsStarted = errors.New("no connections were made when creating the session")
 	// Deprecated: Never used or returned by the driver.
 	ErrHostQueryFailed = errors.New("unable to populate Hosts")
+)
+
+const (
+	metadataCacheDisabledWarningMsg = "Metadata cache is disabled and the host selection policy does not implement MetadataRequiredPolicy interface. " +
+		"This might result in unexpected behavior if your custom policy requires keyspace metadata. " +
+		"To avoid this warning, please implement the MetadataRequiredPolicy interface."
 )

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -30,6 +30,7 @@ package gocql
 import (
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -82,4 +83,71 @@ func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345, nopLoggerSingleton)
 	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
 	assertEqual(t, "translated port", 5432, newPort)
+}
+
+type testHostSelectionPolicy struct {
+	HostSelectionPolicy
+}
+
+func TestClusterConfig_validate_HostSelectionPolicyRequiresMetadata(t *testing.T) {
+	type testCase struct {
+		name                string
+		cacheMode           MetadataCacheMode
+		hostSelectionPolicy HostSelectionPolicy
+		expectedError       error
+
+		// In case when policy doesn't implement MetadataRequiredPolicy interface, and cache is disabled, we expect a warning.
+		expectsWarning bool
+	}
+
+	testCases := []testCase{
+		{
+			name:                "Metadata cache is disabled and policy does not require metadata",
+			cacheMode:           Disabled,
+			hostSelectionPolicy: RoundRobinHostPolicy(),
+			expectedError:       nil,
+		},
+		{
+			name:                "Metadata cache is disabled and policy requires metadata",
+			cacheMode:           Disabled,
+			hostSelectionPolicy: TokenAwareHostPolicy(RoundRobinHostPolicy()),
+			expectedError:       ErrMetadataCacheRequired,
+		},
+		{
+			name:                "Metadata cache is enabled and policy requires metadata",
+			cacheMode:           Full,
+			hostSelectionPolicy: TokenAwareHostPolicy(RoundRobinHostPolicy()),
+			expectedError:       nil,
+		},
+		{
+			name:                "Metadata cache is disabled and the host selection policy does not implement MetadataRequiredPolicy interface",
+			cacheMode:           Disabled,
+			hostSelectionPolicy: testHostSelectionPolicy{},
+			expectedError:       nil,
+			expectsWarning:      true,
+		},
+		{
+			name:                "Metadata cache is enabled",
+			cacheMode:           Full,
+			hostSelectionPolicy: RoundRobinHostPolicy(),
+			expectedError:       nil,
+			expectsWarning:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logger := newTestLogger(LogLevelInfo)
+			cfg := ClusterConfig{
+				Metadata:   MetadataConfig{CacheMode: testCase.cacheMode},
+				PoolConfig: PoolConfig{HostSelectionPolicy: testCase.hostSelectionPolicy},
+				Logger:     logger,
+			}
+			err := cfg.validate()
+			assertEqual(t, "error", testCase.expectedError, err)
+			if testCase.expectsWarning {
+				assertTrue(t, "has warning", strings.Contains(logger.String(), metadataCacheDisabledWarningMsg))
+			}
+		})
+	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -303,6 +303,10 @@ func randomText(size int) string {
 	return string(result)
 }
 
+func randomNameWithPrefix(prefix string) string {
+	return prefix + strings.ToLower(randomText(10))
+}
+
 func assertEqual(t *testing.T, description string, expected, actual interface{}) {
 	t.Helper()
 	if expected != actual {

--- a/hostpool/hostpool.go
+++ b/hostpool/hostpool.go
@@ -43,6 +43,8 @@ func HostPoolHostPolicy(hp hostpool.HostPool) *hostPoolHostPolicy {
 	return &hostPoolHostPolicy{hostMap: map[string]*gocql.HostInfo{}, hp: hp}
 }
 
+var _ gocql.MetadataRequiredPolicy = (*hostPoolHostPolicy)(nil)
+
 type hostPoolHostPolicy struct {
 	hp      hostpool.HostPool
 	mu      sync.RWMutex
@@ -139,6 +141,10 @@ func (r *hostPoolHostPolicy) Pick(qry gocql.ExecutableStatement) gocql.NextHost 
 			hostR:  hostR,
 		}
 	}
+}
+
+func (r *hostPoolHostPolicy) MetadataRequired() bool {
+	return false
 }
 
 // selectedHostPoolHost is a host returned by the hostPoolHostPolicy and

--- a/integration_test.go
+++ b/integration_test.go
@@ -35,9 +35,11 @@ import (
 	"net"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	inf "gopkg.in/inf.v0"
 )
 
@@ -1027,4 +1029,88 @@ func TestSmallTimeoutNoPoolErrors(t *testing.T) {
 		t.Fatalf("Found %d 'Pool connection error' messages - connections are timing out and reconnecting:\n%s",
 			errorCount, logOutput)
 	}
+}
+
+// Emulates round-robin host selection policy and captures KeyspaceChanged events.
+type capturingRRTestPolicy struct {
+	roundRobinHostPolicy
+
+	capturedEvents []KeyspaceUpdateEvent
+	mu             sync.Mutex
+}
+
+func (c *capturingRRTestPolicy) KeyspaceChanged(event KeyspaceUpdateEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.capturedEvents = append(c.capturedEvents, event)
+	c.roundRobinHostPolicy.KeyspaceChanged(event)
+}
+
+func (c *capturingRRTestPolicy) CapturedEvents() []KeyspaceUpdateEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]KeyspaceUpdateEvent{}, c.capturedEvents...)
+}
+
+func (c *capturingRRTestPolicy) ResetEvents() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.capturedEvents = nil
+}
+
+func TestHostSelectionPolicyKeyspaceChangedEvents(t *testing.T) {
+	cluster := createCluster()
+	policy := capturingRRTestPolicy{}
+	cluster.Metadata.CacheMode = Full
+	cluster.PoolConfig.HostSelectionPolicy = &policy
+
+	session, err := cluster.CreateSession()
+	require.NoError(t, err)
+	defer session.Close()
+
+	// Regression test for CASSGO-132: KeyspaceChanged events are fired during session creation.
+	events := policy.CapturedEvents()
+	require.Empty(t, events, "KeyspaceChanged events should not be fired during session creation")
+
+	// Check keyspace events are fired
+
+	// CREATE
+	ksName := randomNameWithPrefix("gocql_test_")
+	err = session.Query(fmt.Sprintf("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", ksName)).ExecContext(context.Background())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		events = policy.CapturedEvents()
+		return len(events) == 1
+	}, time.Second*5, time.Millisecond*100)
+
+	require.Len(t, events, 1)
+	require.Equal(t, ksName, events[0].Keyspace)
+	require.Equal(t, SchemaChangeTypeCreated, events[0].Change)
+
+	// ALTER
+	policy.ResetEvents()
+	err = session.Query(fmt.Sprintf("ALTER KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '2'}", ksName)).ExecContext(context.Background())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		events = policy.CapturedEvents()
+		return len(events) == 1
+	}, time.Second*5, time.Millisecond*100)
+
+	require.Len(t, events, 1)
+	require.Equal(t, ksName, events[0].Keyspace)
+	require.Equal(t, SchemaChangeTypeUpdated, events[0].Change)
+
+	// DROP
+	policy.ResetEvents()
+	err = session.Query(fmt.Sprintf("DROP KEYSPACE %s", ksName)).ExecContext(context.Background())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		events = policy.CapturedEvents()
+		return len(events) == 1
+	}, time.Second*5, time.Millisecond*100)
+
+	require.Len(t, events, 1)
+	require.Equal(t, ksName, events[0].Keyspace)
+	require.Equal(t, SchemaChangeTypeDropped, events[0].Change)
 }

--- a/metadata.go
+++ b/metadata.go
@@ -575,6 +575,10 @@ type schemaDescriber struct {
 // Schema change events are server-initiated messages sent to clients that have registered
 // for schema change notifications. These events indicate modifications to keyspaces, tables,
 // user-defined types, functions, or aggregates.
+//
+// When a schema change event is received, the driver will update its internal metadata
+// by comparing the old and new metadata. If the metadata has changed, the driver will
+// notify [HostSelectionPolicy.KeyspaceChanged] method about the change.
 const (
 	SchemaChangeTypeCreated = "CREATED" // Schema object was created
 	SchemaChangeTypeUpdated = "UPDATED" // Schema object was modified
@@ -858,9 +862,6 @@ func refreshSchemas(session *Session) error {
 
 	// Notify policy if it supports schema refresh notifications
 	notifier, supportsRefresh := session.policy.(schemaRefreshNotifier)
-	hasKeyspaceListener := session.schemaListeners.hasKeyspace() && sessionInitialized
-
-	// Notify the policy if it supports schema refresh notifications
 	if supportsRefresh {
 		notifier.schemaRefreshed(session.schemaDescriber.getSchemaMetaForRead())
 	}
@@ -871,31 +872,36 @@ func refreshSchemas(session *Session) error {
 		NewLogFieldInt("dropped_keyspaces_count", len(droppedKeyspaces)),
 	)
 
-	// If we don't support schemaRefreshed OR we have listeners, we need to loop
-	if !supportsRefresh || hasKeyspaceListener {
+	// We should not call KeyspaceChanged method if policy implements schemaRefreshNotifier.
+	shouldCallKeyspaceChanged := !supportsRefresh && sessionInitialized
+	// We should not notify keyspace listeners if they are not set or session is not initialized yet.
+	shouldNotifyKeyspaceListener := session.schemaListeners.hasKeyspace() && sessionInitialized
+
+	// Loop only if we need to notify policy or keyspace listeners.
+	if shouldCallKeyspaceChanged || shouldNotifyKeyspaceListener {
 		for _, name := range newKeyspaces {
-			if !supportsRefresh {
+			if shouldCallKeyspaceChanged {
 				session.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: name, Change: SchemaChangeTypeCreated})
 			}
-			if hasKeyspaceListener {
+			if shouldNotifyKeyspaceListener {
 				session.schemaListeners.OnKeyspaceCreated(OnKeyspaceCreatedEvent{Keyspace: keyspaces[name].Clone()})
 			}
 		}
 
 		for _, name := range droppedKeyspaces {
-			if !supportsRefresh {
+			if shouldCallKeyspaceChanged {
 				session.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: name, Change: SchemaChangeTypeDropped})
 			}
-			if hasKeyspaceListener {
+			if shouldNotifyKeyspaceListener {
 				session.schemaListeners.OnKeyspaceDropped(OnKeyspaceDroppedEvent{Keyspace: oldKeyspaceMeta[name].Clone()})
 			}
 		}
 
 		for _, name := range updatedKeyspaces {
-			if !supportsRefresh {
+			if shouldCallKeyspaceChanged {
 				session.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: name, Change: SchemaChangeTypeUpdated})
 			}
-			if hasKeyspaceListener {
+			if shouldNotifyKeyspaceListener {
 				session.schemaListeners.OnKeyspaceUpdated(OnKeyspaceUpdatedEvent{
 					Old: oldKeyspaceMeta[name].Clone(),
 					New: keyspaces[name].Clone(),

--- a/policies.go
+++ b/policies.go
@@ -38,6 +38,14 @@ import (
 	"time"
 )
 
+var (
+	_ MetadataRequiredPolicy = (*roundRobinHostPolicy)(nil)
+	_ MetadataRequiredPolicy = (*tokenAwareHostPolicy)(nil)
+	_ MetadataRequiredPolicy = (*dcAwareRR)(nil)
+	_ MetadataRequiredPolicy = (*rackAwareRR)(nil)
+	_ MetadataRequiredPolicy = (*singleHostReadyPolicy)(nil)
+)
+
 // cowHostList implements a copy on write host list, its equivalent type is []*HostInfo
 type cowHostList struct {
 	list atomic.Value
@@ -340,6 +348,15 @@ type schemaRefreshNotifier interface {
 	schemaRefreshed(meta *schemaMeta)
 }
 
+// MetadataRequiredPolicy is an optional interface that can be implemented by HostSelectionPolicy.
+// If implemented, the policy will be queried to determine if metadata is required for the policy to work.
+// If metadata is required and MetadataCacheMode is not set to at least KeyspaceOnly, it will result in an error during session creation.
+//
+// All built-in policies implement this interface.
+type MetadataRequiredPolicy interface {
+	MetadataRequired() bool
+}
+
 // SelectedHost is an interface returned when picking a host from a host
 // selection policy.
 type SelectedHost interface {
@@ -396,6 +413,10 @@ func (r *roundRobinHostPolicy) HostDown(host *HostInfo) {
 	r.RemoveHost(host)
 }
 
+func (r *roundRobinHostPolicy) MetadataRequired() bool {
+	return false
+}
+
 // ShuffleReplicas returns an option function to enable shuffling of replicas in token-aware host selection.
 // When enabled, the set of replicas for a partition key will be traversed in randomized order.
 func ShuffleReplicas() func(*tokenAwareHostPolicy) {
@@ -427,6 +448,9 @@ func NonLocalReplicasFallback() func(policy *tokenAwareHostPolicy) {
 }
 
 // ShuffledTokenAwareHostPolicy is a token aware host selection policy that shuffles replicas.
+//
+// Note: TokenAwareHostPolicy requires the metadata cache to be enabled.
+// See [ClusterConfig.Metadata] for more details.
 func ShuffledTokenAwareHostPolicy(fallback HostSelectionPolicy, opts ...func(*tokenAwareHostPolicy)) HostSelectionPolicy {
 	p := &tokenAwareHostPolicy{
 		fallback:                fallback,
@@ -442,6 +466,9 @@ func ShuffledTokenAwareHostPolicy(fallback HostSelectionPolicy, opts ...func(*to
 // TokenAwareHostPolicy is a token aware host selection policy, where hosts are
 // selected based on the partition key, so queries are sent to the host which
 // owns the partition. Fallback is used when routing information is not available.
+//
+// Note: TokenAwareHostPolicy requires the metadata cache to be enabled.
+// See [ClusterConfig.Metadata] for more details.
 func TokenAwareHostPolicy(fallback HostSelectionPolicy, opts ...func(*tokenAwareHostPolicy)) HostSelectionPolicy {
 	p := &tokenAwareHostPolicy{fallback: fallback}
 	for _, opt := range opts {
@@ -799,6 +826,11 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableStatement) NextHost {
 	}
 }
 
+// Always require metadata for token-aware host selection.
+func (t *tokenAwareHostPolicy) MetadataRequired() bool {
+	return true
+}
+
 type dcAwareRR struct {
 	local           string
 	localHosts      cowHostList
@@ -839,6 +871,10 @@ func (d *dcAwareRR) RemoveHost(host *HostInfo) {
 
 func (d *dcAwareRR) HostUp(host *HostInfo)   { d.AddHost(host) }
 func (d *dcAwareRR) HostDown(host *HostInfo) { d.RemoveHost(host) }
+
+func (d *dcAwareRR) MetadataRequired() bool {
+	return false
+}
 
 // This function is supposed to be called in a fashion
 // roundRobbin(offset, hostsPriority1, hostsPriority2, hostsPriority3 ... )
@@ -948,6 +984,10 @@ func (d *rackAwareRR) Pick(q ExecutableStatement) NextHost {
 	return roundRobbin(int(nextStartOffset), d.hosts[0].get(), d.hosts[1].get(), d.hosts[2].get())
 }
 
+func (d *rackAwareRR) MetadataRequired() bool {
+	return false
+}
+
 // ReadyPolicy defines a policy for when a HostSelectionPolicy can be used. After
 // each host connects during session initialization, the Ready method will be
 // called. If you only need a single Host to be up you can wrap a
@@ -991,6 +1031,13 @@ func (s *singleHostReadyPolicy) Ready() bool {
 		return rdy.Ready()
 	}
 	return true
+}
+
+// Requires metadata if the wrapped policy requires it.
+// If the wrapped policy does not implement MetadataRequiredPolicy, returns false.
+func (s *singleHostReadyPolicy) MetadataRequired() bool {
+	fallback, ok := s.HostSelectionPolicy.(MetadataRequiredPolicy)
+	return ok && fallback.MetadataRequired()
 }
 
 // ConvictionPolicy interface is used by gocql to determine if a host should be

--- a/schema_events_test.go
+++ b/schema_events_test.go
@@ -23,7 +23,6 @@ package gocql
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -261,10 +260,6 @@ func testSchemaEventsKeyspace(t *testing.T, session *Session, listener *schemaCh
 
 	// Verify that the listener received the keyspace dropped event
 	require.Equal(t, ks, listener.KeyspaceDroppedEvents[0].Keyspace.Name, "Expected keyspace dropped event to have correct keyspace name")
-}
-
-func randomNameWithPrefix(prefix string) string {
-	return prefix + strings.ToLower(randomText(10))
 }
 
 func testSchemaEventsTable(t *testing.T, session *Session, listener *schemaChangesTestListener) {

--- a/session.go
+++ b/session.go
@@ -149,6 +149,14 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		return nil, fmt.Errorf("the default SerialConsistency level is not allowed to be anything else but SERIAL or LOCAL_SERIAL. Recived value: %v", cfg.SerialConsistency)
 	}
 
+	if cfg.PoolConfig.HostSelectionPolicy == nil {
+		cfg.PoolConfig.HostSelectionPolicy = RoundRobinHostPolicy()
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	// TODO: we should take a context in here at some point
 	ctx, cancel := context.WithCancel(context.TODO())
 
@@ -222,9 +230,6 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	}
 	s.connCfg = connCfg
 
-	if cfg.PoolConfig.HostSelectionPolicy == nil {
-		cfg.PoolConfig.HostSelectionPolicy = RoundRobinHostPolicy()
-	}
 	s.pool = cfg.PoolConfig.buildPool(s)
 	s.policy = cfg.PoolConfig.HostSelectionPolicy
 
@@ -2525,16 +2530,17 @@ func (e Error) Error() string {
 }
 
 var (
-	ErrNotFound             = errors.New("not found")
-	ErrUnavailable          = errors.New("unavailable")
-	ErrUnsupported          = errors.New("feature not supported")
-	ErrTooManyStmts         = errors.New("too many statements")
-	ErrUseStmt              = errors.New("use statements aren't supported. Please see https://github.com/apache/cassandra-gocql-driver for explanation.")
-	ErrSessionClosed        = errors.New("session has been closed")
-	ErrNoConnections        = errors.New("gocql: no hosts available in the pool")
-	ErrNoKeyspace           = errors.New("no keyspace provided")
-	ErrKeyspaceDoesNotExist = errors.New("keyspace does not exist")
-	ErrNoMetadata           = errors.New("no metadata available")
+	ErrNotFound              = errors.New("not found")
+	ErrUnavailable           = errors.New("unavailable")
+	ErrUnsupported           = errors.New("feature not supported")
+	ErrTooManyStmts          = errors.New("too many statements")
+	ErrUseStmt               = errors.New("use statements aren't supported. Please see https://github.com/apache/cassandra-gocql-driver for explanation.")
+	ErrSessionClosed         = errors.New("session has been closed")
+	ErrNoConnections         = errors.New("gocql: no hosts available in the pool")
+	ErrNoKeyspace            = errors.New("no keyspace provided")
+	ErrKeyspaceDoesNotExist  = errors.New("keyspace does not exist")
+	ErrNoMetadata            = errors.New("no metadata available")
+	ErrMetadataCacheRequired = errors.New("metadata cache must be enabled for the selected host selection policy")
 )
 
 // ErrProtocol represents a protocol-level error.


### PR DESCRIPTION
This patch fixes a regression introduced in CASSGO-104 that caused the driver to fire synthetic CREATED events on HostSelectionPolicy.KeyspaceChanged for each existing keyspace during session initialization.