### PR TITLE
CASSGO-134 zero *[16]byte on null uuid unmarshal

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -2251,10 +2251,12 @@ func uuidUnmarshal(kind string, data []byte, value interface{}) error {
 			*v = nil
 		case *UUID:
 			*v = UUID{}
+		case *[16]byte:
+			*v = UUID{}
 		case *interface{}:
 			*v = UUID{}
 		default:
-			return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *UUID, *[]byte, *string, *interface{}.", kind, value)
+			return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *UUID, *[16]byte, *[]byte, *string, *interface{}.", kind, value)
 		}
 
 		return nil
@@ -2291,7 +2293,7 @@ func uuidUnmarshal(kind string, data []byte, value interface{}) error {
 		*v = u[:]
 		return nil
 	}
-	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *UUID, *[]byte, *string, *interface{}.", kind, value)
+	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *UUID, *[16]byte, *[]byte, *string, *interface{}.", kind, value)
 }
 
 type timeUUIDType struct{}
@@ -2319,6 +2321,10 @@ func (t timeUUIDType) Marshal(value interface{}) ([]byte, error) {
 func (t timeUUIDType) Unmarshal(data []byte, value interface{}) error {
 	switch v := value.(type) {
 	case *time.Time:
+		if len(data) == 0 {
+			*v = time.Time{}
+			return nil
+		}
 		id, err := UUIDFromBytes(data)
 		if err != nil {
 			return err

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1322,6 +1322,24 @@ var unmarshalTests = []struct {
 		}(),
 		nil,
 	},
+	{
+		uuidType{},
+		[]byte(nil),
+		[16]byte{},
+		nil,
+	},
+	{
+		timeUUIDType{},
+		[]byte(nil),
+		[16]byte{},
+		nil,
+	},
+	{
+		timeUUIDType{},
+		[]byte(nil),
+		time.Time{},
+		nil,
+	},
 }
 
 func decimalize(s string) *inf.Dec {


### PR DESCRIPTION
Fixes #CASSGO-134
Unmarshaling a null (empty) uuid/timeuuid value into *[16]byte returned an error instead of setting the zero value, unlike the other supported target types. Similarly, timeUUIDType.Unmarshal passed empty data to UUIDFromBytes for *time.Time, failing with "UUIDs must be exactly 16 bytes long". Both now set the zero value, consistent with the other null-data branches. Added table-driven test cases covering these paths.