### PR TITLE
Do not panic on a bare or truncated CompositeType

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -2254,6 +2254,9 @@ func (t *typeParser) parse() (typeParserResult, bool, error) {
 	// interpret the AST
 	if strings.HasPrefix(ast.name, COMPOSITE_TYPE) {
 		count := len(ast.params)
+		if count == 0 {
+			return typeParserResult{}, false, nil
+		}
 
 		// look for a collections param
 		last := ast.params[count-1]
@@ -2280,6 +2283,9 @@ func (t *typeParser) parse() (typeParserResult, bool, error) {
 			class := param.class
 			reversed[i] = strings.HasPrefix(class.name, REVERSED_TYPE)
 			if reversed[i] {
+				if len(class.params) == 0 {
+					return typeParserResult{}, false, nil
+				}
 				class = class.params[0].class
 			}
 			types[i], err = class.asTypeInfo()
@@ -2385,7 +2391,7 @@ func (t *typeParser) parseParamNodes() (params []typeParserParamNode, ok bool) {
 
 	t.skipWhitespace()
 
-	for t.input[t.index] != ')' {
+	for t.index < len(t.input) && t.input[t.index] != ')' {
 		// look for a named param, but if no colon, then we want to backup
 		backupIndex := t.index
 
@@ -2400,7 +2406,7 @@ func (t *typeParser) parseParamNodes() (params []typeParserParamNode, ok bool) {
 
 		t.skipWhitespace()
 
-		if t.input[t.index] == ':' {
+		if t.index < len(t.input) && t.input[t.index] == ':' {
 			// there is a name for this parameter
 
 			// consume the ':'
@@ -2433,12 +2439,16 @@ func (t *typeParser) parseParamNodes() (params []typeParserParamNode, ok bool) {
 
 		t.skipWhitespace()
 
-		if t.input[t.index] == ',' {
+		if t.index < len(t.input) && t.input[t.index] == ',' {
 			// consume the comma
 			t.index++
 
 			t.skipWhitespace()
 		}
+	}
+
+	if t.index >= len(t.input) || t.input[t.index] != ')' {
+		return nil, false
 	}
 
 	// consume the ')'

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -424,6 +424,33 @@ type assertTypeInfo struct {
 	Custom   string
 }
 
+func TestParseTypeBareCompositeDoesNotPanic(t *testing.T) {
+	session := &Session{
+		cfg: ClusterConfig{
+			ProtoVersion: 4,
+		},
+		logger: NewLogger(LogLevelNone),
+		types:  GlobalTypes,
+	}
+	inputs := []string{
+		"org.apache.cassandra.db.marshal.CompositeType",
+		"org.apache.cassandra.db.marshal.CompositeType(",
+		"org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type",
+	}
+	for _, def := range inputs {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Errorf("parseType(%q) panicked: %v", def, rec)
+				}
+			}()
+			if _, err := parseType(session, def); err != nil {
+				t.Errorf("parseType(%q) error: %v", def, err)
+			}
+		}()
+	}
+}
+
 // Helper function for asserting that the type parser returns the expected
 // results for the given definition
 func assertParseNonCompositeType(


### PR DESCRIPTION
`parseType` indexed `params[count-1]` without checking length, and `parseParamNodes` read past the end of an unterminated parameter list.

Treat those inputs as unparsable instead of panicking.

Fixes #1963

## Test
`go test -tags unit -run TestParseTypeBareCompositeDoesNotPanic -count=1`
